### PR TITLE
Feature/3 token form

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - Flutter (1.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+
+PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -10,10 +10,12 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		54F8B12C3AEFE7911D4DD1B2 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8F90DF080897A9C9E5BB893 /* Pods_RunnerTests.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		C9C9E0DDD8F7A35F8ED6C7CB /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 676D5205EB7C6BF974B160BF /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,9 +47,13 @@
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		5BED9911E7D0C6639E6F75A3 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		676D5205EB7C6BF974B160BF /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		8B724EB521A7EBA33CC284A7 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		943F05B94D617684EB57C718 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,13 +61,26 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A473ACAB69726D65D0EAB8FD /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		B44F7935094AC6E63D758204 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		C8F90DF080897A9C9E5BB893 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D28B60AEEA3BC1E287EB4713 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		46BF576D682B5A8394F5DBF1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				54F8B12C3AEFE7911D4DD1B2 /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C9C9E0DDD8F7A35F8ED6C7CB /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,6 +113,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				A7A7C231115A2FFBCFE6B783 /* Pods */,
+				E65F26275A7B121671793574 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,6 +142,29 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		A7A7C231115A2FFBCFE6B783 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				8B724EB521A7EBA33CC284A7 /* Pods-Runner.debug.xcconfig */,
+				D28B60AEEA3BC1E287EB4713 /* Pods-Runner.release.xcconfig */,
+				A473ACAB69726D65D0EAB8FD /* Pods-Runner.profile.xcconfig */,
+				5BED9911E7D0C6639E6F75A3 /* Pods-RunnerTests.debug.xcconfig */,
+				943F05B94D617684EB57C718 /* Pods-RunnerTests.release.xcconfig */,
+				B44F7935094AC6E63D758204 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		E65F26275A7B121671793574 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				676D5205EB7C6BF974B160BF /* Pods_Runner.framework */,
+				C8F90DF080897A9C9E5BB893 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				C5AF4766324A1ACF11719FC4 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				46BF576D682B5A8394F5DBF1 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				29F24A1F13E46F06D175F947 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				625187126A5ECC4483C6BE7F /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,6 +270,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		29F24A1F13E46F06D175F947 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -238,6 +308,23 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		625187126A5ECC4483C6BE7F /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -252,6 +339,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		C5AF4766324A1ACF11719FC4 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -379,6 +488,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5BED9911E7D0C6639E6F75A3 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -396,6 +506,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 943F05B94D617684EB57C718 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -411,6 +522,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = B44F7935094AC6E63D758204 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,18 +1,62 @@
 import 'package:flutter/material.dart';
 import 'core/router/app_router.dart';
 import 'core/theme/app_theme.dart';
+import 'core/theme/theme_notifier.dart';
+import 'features/settings/data/datasources/theme_local_datasource.dart';
+import 'features/settings/data/repositories/theme_repository_impl.dart';
+import 'features/settings/domain/repositories/theme_repository.dart';
 
-class App extends StatelessWidget {
+class App extends StatefulWidget {
   const App({super.key});
 
   @override
+  State<App> createState() => _AppState();
+}
+
+class _AppState extends State<App> {
+  final themeRepository = ThemeRepositoryImpl(ThemeLocalDataSource()) as ThemeRepository;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadThemeMode();
+    // テーマ変更を監視
+    themeNotifier.addListener(_onThemeChanged);
+  }
+
+  @override
+  void dispose() {
+    themeNotifier.removeListener(_onThemeChanged);
+    super.dispose();
+  }
+
+  void _loadThemeMode() async {
+    try {
+      final savedThemeMode = await themeRepository.getThemeMode();
+      themeNotifier.updateThemeMode(savedThemeMode.toThemeMode());
+    } catch (e) {
+      // エラー時はデフォルトのsystemを使用
+      themeNotifier.updateThemeMode(ThemeMode.system);
+    }
+  }
+
+  void _onThemeChanged() {
+    setState(() {});
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      title: 'GitHub Contribution App',
-      theme: AppTheme.lightTheme,
-      darkTheme: AppTheme.darkTheme,
-      themeMode: ThemeMode.system,
-      routerConfig: appRouter,
+    return ValueListenableBuilder<ThemeMode>(
+      valueListenable: themeNotifier,
+      builder: (context, themeMode, child) {
+        return MaterialApp.router(
+          title: 'GitHub Contribution App',
+          theme: AppTheme.lightTheme,
+          darkTheme: AppTheme.darkTheme,
+          themeMode: themeMode,
+          routerConfig: appRouter,
+        );
+      },
     );
   }
 }

--- a/lib/core/theme/theme_notifier.dart
+++ b/lib/core/theme/theme_notifier.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+/// テーマ変更を通知するNotifier
+class ThemeNotifier extends ValueNotifier<ThemeMode> {
+  ThemeNotifier() : super(ThemeMode.system);
+
+  /// テーマモードを更新する
+  void updateThemeMode(ThemeMode mode) {
+    value = mode;
+  }
+}
+
+/// グローバルなテーマNotifier
+final themeNotifier = ThemeNotifier();

--- a/lib/features/settings/data/datasources/theme_local_datasource.dart
+++ b/lib/features/settings/data/datasources/theme_local_datasource.dart
@@ -1,0 +1,17 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// テーマ設定のローカルストレージアクセス
+class ThemeLocalDataSource {
+  static const String _themeModeKey = 'app_theme_mode';
+
+  Future<void> saveThemeMode(String themeMode) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_themeModeKey, themeMode);
+  }
+
+  Future<String?> getThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_themeModeKey);
+  }
+}
+

--- a/lib/features/settings/data/datasources/token_local_datasource.dart
+++ b/lib/features/settings/data/datasources/token_local_datasource.dart
@@ -1,0 +1,24 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// ローカルストレージ（SharedPreferences）へのアクセスを管理するDataSource
+class TokenLocalDataSource {
+  static const String _tokenKey = 'github_personal_access_token';
+
+  /// トークンを保存する
+  Future<void> saveToken(String token) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_tokenKey, token);
+  }
+
+  /// トークンを取得する
+  Future<String?> getToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_tokenKey);
+  }
+
+  /// トークンを削除する
+  Future<void> deleteToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_tokenKey);
+  }
+}

--- a/lib/features/settings/data/repositories/theme_repository_impl.dart
+++ b/lib/features/settings/data/repositories/theme_repository_impl.dart
@@ -1,0 +1,24 @@
+import '../../domain/entities/theme_mode.dart';
+import '../../domain/repositories/theme_repository.dart';
+import '../datasources/theme_local_datasource.dart';
+
+/// ThemeRepositoryの実装
+class ThemeRepositoryImpl implements ThemeRepository {
+  final ThemeLocalDataSource dataSource;
+
+  ThemeRepositoryImpl(this.dataSource);
+
+  @override
+  Future<void> saveThemeMode(AppThemeMode themeMode) async {
+    await dataSource.saveThemeMode(themeMode.toValue());
+  }
+
+  @override
+  Future<AppThemeMode> getThemeMode() async {
+    final themeModeValue = await dataSource.getThemeMode();
+    if (themeModeValue == null) {
+      return AppThemeMode.system;
+    }
+    return AppThemeMode.fromString(themeModeValue);
+  }
+}

--- a/lib/features/settings/data/repositories/token_repository_impl.dart
+++ b/lib/features/settings/data/repositories/token_repository_impl.dart
@@ -1,0 +1,27 @@
+import '../../domain/entities/token.dart';
+import '../../domain/repositories/token_repository.dart';
+import '../datasources/token_local_datasource.dart';
+
+/// TokenRepositoryの実装
+class TokenRepositoryImpl implements TokenRepository {
+  final TokenLocalDataSource dataSource;
+
+  TokenRepositoryImpl(this.dataSource);
+
+  @override
+  Future<void> saveToken(Token token) async {
+    await dataSource.saveToken(token.value);
+  }
+
+  @override
+  Future<Token?> getToken() async {
+    final tokenValue = await dataSource.getToken();
+    if (tokenValue == null) return null;
+    return Token(tokenValue);
+  }
+
+  @override
+  Future<void> deleteToken() async {
+    await dataSource.deleteToken();
+  }
+}

--- a/lib/features/settings/domain/entities/theme_mode.dart
+++ b/lib/features/settings/domain/entities/theme_mode.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+/// テーマモードのエンティティ
+enum AppThemeMode {
+  light,
+  dark,
+  system;
+
+  /// 文字列から変換
+  static AppThemeMode fromString(String value) {
+    switch (value) {
+      case 'light':
+        return AppThemeMode.light;
+      case 'dark':
+        return AppThemeMode.dark;
+      case 'system':
+      default:
+        return AppThemeMode.system;
+    }
+  }
+
+  /// 文字列に変換
+  String toValue() {
+    switch (this) {
+      case AppThemeMode.light:
+        return 'light';
+      case AppThemeMode.dark:
+        return 'dark';
+      case AppThemeMode.system:
+        return 'system';
+    }
+  }
+
+  /// FlutterのThemeModeに変換
+  ThemeMode toThemeMode() {
+    switch (this) {
+      case AppThemeMode.light:
+        return ThemeMode.light;
+      case AppThemeMode.dark:
+        return ThemeMode.dark;
+      case AppThemeMode.system:
+        return ThemeMode.system;
+    }
+  }
+}

--- a/lib/features/settings/domain/entities/token.dart
+++ b/lib/features/settings/domain/entities/token.dart
@@ -1,0 +1,24 @@
+/// Personal Access Token エンティティ
+class Token {
+  final String value;
+
+  const Token(this.value);
+
+  /// トークンが有効かどうかをチェック
+  bool get isValid {
+    // GitHub Personal Access Token は通常40文字の英数字
+    // または ghp_ で始まる新しい形式
+    if (value.isEmpty) return false;
+    if (value.length < 20) return false;
+    return true;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Token && runtimeType == other.runtimeType && value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+}
+

--- a/lib/features/settings/domain/repositories/theme_repository.dart
+++ b/lib/features/settings/domain/repositories/theme_repository.dart
@@ -1,0 +1,10 @@
+import '../entities/theme_mode.dart';
+
+/// テーマ設定のリポジトリインターフェース
+abstract class ThemeRepository {
+  /// テーマモードを保存する
+  Future<void> saveThemeMode(AppThemeMode themeMode);
+
+  /// テーマモードを取得する
+  Future<AppThemeMode> getThemeMode();
+}

--- a/lib/features/settings/domain/repositories/token_repository.dart
+++ b/lib/features/settings/domain/repositories/token_repository.dart
@@ -1,0 +1,14 @@
+import '../entities/token.dart';
+
+/// Token保存・取得のリポジトリインターフェース
+abstract class TokenRepository {
+  /// トークンを保存する
+  Future<void> saveToken(Token token);
+
+  /// トークンを取得する
+  Future<Token?> getToken();
+
+  /// トークンを削除する
+  Future<void> deleteToken();
+}
+

--- a/lib/features/settings/domain/usecases/get_theme_mode_usecase.dart
+++ b/lib/features/settings/domain/usecases/get_theme_mode_usecase.dart
@@ -1,0 +1,14 @@
+import '../entities/theme_mode.dart';
+import '../repositories/theme_repository.dart';
+
+/// テーマモードを取得するUseCase
+class GetThemeModeUseCase {
+  final ThemeRepository repository;
+
+  GetThemeModeUseCase(this.repository);
+
+  Future<AppThemeMode> call() async {
+    return await repository.getThemeMode();
+  }
+}
+

--- a/lib/features/settings/domain/usecases/get_token_usecase.dart
+++ b/lib/features/settings/domain/usecases/get_token_usecase.dart
@@ -1,0 +1,17 @@
+import '../entities/token.dart';
+import '../repositories/token_repository.dart';
+
+/// トークンを取得するUseCase
+class GetTokenUseCase {
+  final TokenRepository repository;
+
+  GetTokenUseCase(this.repository);
+
+  /// 保存されているトークンを取得する
+  /// 
+  /// Returns [Token] if exists, null otherwise
+  Future<Token?> call() async {
+    return await repository.getToken();
+  }
+}
+

--- a/lib/features/settings/domain/usecases/save_theme_mode_usecase.dart
+++ b/lib/features/settings/domain/usecases/save_theme_mode_usecase.dart
@@ -1,0 +1,14 @@
+import '../entities/theme_mode.dart';
+import '../repositories/theme_repository.dart';
+
+/// テーマモードを保存するUseCase
+class SaveThemeModeUseCase {
+  final ThemeRepository repository;
+
+  SaveThemeModeUseCase(this.repository);
+
+  Future<void> call(AppThemeMode themeMode) async {
+    await repository.saveThemeMode(themeMode);
+  }
+}
+

--- a/lib/features/settings/domain/usecases/save_token_usecase.dart
+++ b/lib/features/settings/domain/usecases/save_token_usecase.dart
@@ -1,0 +1,22 @@
+import '../entities/token.dart';
+import '../repositories/token_repository.dart';
+
+/// トークンを保存するUseCase
+class SaveTokenUseCase {
+  final TokenRepository repository;
+
+  SaveTokenUseCase(this.repository);
+
+  /// トークンを保存する
+  /// 
+  /// [token] 保存するトークン
+  /// 
+  /// Throws [Exception] if token is invalid
+  Future<void> call(Token token) async {
+    if (!token.isValid) {
+      throw Exception('トークンが無効です。20文字以上の文字列を入力してください。');
+    }
+    await repository.saveToken(token);
+  }
+}
+

--- a/lib/features/settings/presentation/providers/theme_provider.dart
+++ b/lib/features/settings/presentation/providers/theme_provider.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import '../../../../core/theme/theme_notifier.dart';
+import '../../domain/entities/theme_mode.dart';
+import '../../domain/usecases/save_theme_mode_usecase.dart';
+import '../../domain/usecases/get_theme_mode_usecase.dart';
+
+/// テーマ管理用のHook
+ThemeState useTheme({
+  required SaveThemeModeUseCase saveThemeModeUseCase,
+  required GetThemeModeUseCase getThemeModeUseCase,
+  required BuildContext context,
+}) {
+  final currentThemeMode = useState<AppThemeMode>(AppThemeMode.system);
+  final isLoading = useState<bool>(false);
+
+  /// 初期化時に保存されているテーマモードを読み込む
+  useEffect(() {
+    Future.microtask(() async {
+      isLoading.value = true;
+      try {
+        final savedThemeMode = await getThemeModeUseCase();
+        currentThemeMode.value = savedThemeMode;
+      } catch (e) {
+        // エラー時はデフォルトのsystemを使用
+        currentThemeMode.value = AppThemeMode.system;
+      } finally {
+        isLoading.value = false;
+      }
+    });
+    return null;
+  }, []);
+
+  /// テーマモードを変更する
+  Future<void> changeThemeMode(AppThemeMode themeMode) async {
+    if (currentThemeMode.value == themeMode) return;
+
+    isLoading.value = true;
+    try {
+      await saveThemeModeUseCase(themeMode);
+      currentThemeMode.value = themeMode;
+      // グローバルなテーマNotifierを更新
+      themeNotifier.updateThemeMode(themeMode.toThemeMode());
+    } catch (e) {
+      // エラーハンドリング
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  return ThemeState(
+    currentThemeMode: currentThemeMode.value,
+    isLoading: isLoading.value,
+    changeThemeMode: changeThemeMode,
+  );
+}
+
+/// テーマの状態を保持するクラス
+class ThemeState {
+  final AppThemeMode currentThemeMode;
+  final bool isLoading;
+  final Future<void> Function(AppThemeMode) changeThemeMode;
+
+  ThemeState({
+    required this.currentThemeMode,
+    required this.isLoading,
+    required this.changeThemeMode,
+  });
+}
+

--- a/lib/features/settings/presentation/providers/token_provider.dart
+++ b/lib/features/settings/presentation/providers/token_provider.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
+import '../../domain/entities/token.dart';
+import '../../domain/usecases/save_token_usecase.dart';
+import '../../domain/usecases/get_token_usecase.dart';
+
+/// トークン管理用のHook
+TokenState useToken({
+  required SaveTokenUseCase saveTokenUseCase,
+  required GetTokenUseCase getTokenUseCase,
+}) {
+  final token = useState<String>('');
+  final isLoading = useState<bool>(false);
+  final error = useState<String?>(null);
+  final isSaved = useState<bool>(false);
+
+  /// 初期化時に保存されているトークンを読み込む
+  useEffect(() {
+    Future.microtask(() async {
+      isLoading.value = true;
+      try {
+        final savedToken = await getTokenUseCase();
+        if (savedToken != null) {
+          token.value = savedToken.value;
+          isSaved.value = true;
+        }
+      } catch (e) {
+        error.value = 'トークンの読み込みに失敗しました';
+      } finally {
+        isLoading.value = false;
+      }
+    });
+    return null;
+  }, []);
+
+  /// トークンを保存する
+  Future<void> saveToken() async {
+    if (token.value.isEmpty) {
+      error.value = 'トークンを入力してください';
+      return;
+    }
+
+    isLoading.value = true;
+    error.value = null;
+    isSaved.value = false;
+
+    try {
+      final tokenEntity = Token(token.value);
+      await saveTokenUseCase(tokenEntity);
+      isSaved.value = true;
+      error.value = null;
+    } catch (e) {
+      error.value = e.toString().replaceAll('Exception: ', '');
+      isSaved.value = false;
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  return TokenState(
+    token: token.value,
+    setToken: (value) {
+      token.value = value;
+      error.value = null;
+      isSaved.value = false;
+    },
+    isLoading: isLoading.value,
+    error: error.value,
+    isSaved: isSaved.value,
+    saveToken: saveToken,
+  );
+}
+
+/// トークンの状態を保持するクラス
+class TokenState {
+  final String token;
+  final void Function(String) setToken;
+  final bool isLoading;
+  final String? error;
+  final bool isSaved;
+  final Future<void> Function() saveToken;
+
+  TokenState({
+    required this.token,
+    required this.setToken,
+    required this.isLoading,
+    required this.error,
+    required this.isSaved,
+    required this.saveToken,
+  });
+}
+

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -1,48 +1,334 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import '../../../../core/theme/app_colors.dart';
+import '../../../../shared/widgets/glass_container.dart';
+import '../providers/token_provider.dart';
+import '../providers/theme_provider.dart';
+import '../widgets/error_message_widget.dart';
+import '../widgets/success_message_widget.dart';
+import '../widgets/section_title.dart';
+import '../widgets/save_button.dart';
+import '../../domain/usecases/save_token_usecase.dart';
+import '../../domain/usecases/get_token_usecase.dart';
+import '../../domain/usecases/save_theme_mode_usecase.dart';
+import '../../domain/usecases/get_theme_mode_usecase.dart';
+import '../../data/datasources/token_local_datasource.dart';
+import '../../data/datasources/theme_local_datasource.dart';
+import '../../data/repositories/token_repository_impl.dart';
+import '../../data/repositories/theme_repository_impl.dart';
+import '../../domain/repositories/token_repository.dart';
+import '../../domain/repositories/theme_repository.dart';
+import '../../domain/entities/theme_mode.dart';
 
-class SettingsScreen extends StatelessWidget {
+class SettingsScreen extends HookWidget {
   const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    // DI: 依存関係を構築
+    final tokenRepository = useMemoized(
+      () => TokenRepositoryImpl(TokenLocalDataSource()) as TokenRepository,
+    );
+    final saveTokenUseCase = useMemoized(
+      () => SaveTokenUseCase(tokenRepository),
+    );
+    final getTokenUseCase = useMemoized(() => GetTokenUseCase(tokenRepository));
+
+    final tokenState = useToken(
+      saveTokenUseCase: saveTokenUseCase,
+      getTokenUseCase: getTokenUseCase,
+    );
+
+    // テーマ設定用の依存関係を構築
+    final themeRepository = useMemoized(
+      () => ThemeRepositoryImpl(ThemeLocalDataSource()) as ThemeRepository,
+    );
+    final saveThemeModeUseCase = useMemoized(
+      () => SaveThemeModeUseCase(themeRepository),
+    );
+    final getThemeModeUseCase = useMemoized(
+      () => GetThemeModeUseCase(themeRepository),
+    );
+
+    final themeState = useTheme(
+      saveThemeModeUseCase: saveThemeModeUseCase,
+      getThemeModeUseCase: getThemeModeUseCase,
+      context: context,
+    );
+
     final brightness = Theme.of(context).brightness;
     final textColor = AppColors.textColor(brightness);
     final iconColor = AppColors.iconColor(brightness);
-    final backgroundColor = brightness == Brightness.dark
-        ? AppColors.githubDarkSurface.withValues(alpha: 0.9)
-        : AppColors.white.withValues(alpha: 0.95);
 
     return Center(
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 24),
-        padding: const EdgeInsets.all(32),
-        decoration: BoxDecoration(
-          color: backgroundColor,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(
-            color: AppColors.borderColor(brightness),
-            width: 1,
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+        child: GlassContainer(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _TokenInputForm(
+                tokenState: tokenState,
+                textColor: textColor,
+                iconColor: iconColor,
+              ),
+              const SizedBox(height: 32),
+              _ThemeModeSelector(
+                themeState: themeState,
+                textColor: textColor,
+                iconColor: iconColor,
+              ),
+            ],
           ),
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.settings, size: 64, color: iconColor),
-            const SizedBox(height: 16),
-            Text(
-              '設定画面',
-              style: TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-                color: textColor,
+      ),
+    );
+  }
+}
+
+/// トークン入力フォーム
+class _TokenInputForm extends HookWidget {
+  final TokenState tokenState;
+  final Color textColor;
+  final Color iconColor;
+
+  const _TokenInputForm({
+    required this.tokenState,
+    required this.textColor,
+    required this.iconColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final isDark = brightness == Brightness.dark;
+    final controller = useTextEditingController(text: tokenState.token);
+
+    // tokenState.tokenが変更されたときにcontrollerを更新
+    useEffect(() {
+      if (controller.text != tokenState.token) {
+        controller.text = tokenState.token;
+      }
+      return null;
+    }, [tokenState.token]);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 16),
+        SectionTitle(
+          title: 'Personal Access Token',
+          description: 'GitHub APIにアクセスするためのトークンを入力してください',
+          textColor: textColor,
+        ),
+        const SizedBox(height: 16),
+        TextField(
+          controller: controller,
+          onChanged: tokenState.setToken,
+          obscureText: true,
+          enabled: !tokenState.isLoading,
+          style: TextStyle(color: textColor),
+          decoration: InputDecoration(
+            hintText: 'ghp_xxxxxxxxxxxxxxxxxxxx',
+            hintStyle: TextStyle(color: textColor),
+            prefixIcon: Icon(Icons.lock, color: iconColor),
+            filled: true,
+            fillColor: isDark
+                ? AppColors.githubDarkBg.withValues(alpha: 0.3)
+                : AppColors.githubLightBg.withValues(alpha: 0.5),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(16),
+              borderSide: BorderSide(
+                color: AppColors.borderColor(brightness).withValues(alpha: 0.5),
               ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              'アプリの設定を変更できます',
-              style: TextStyle(fontSize: 16, color: textColor.withOpacity(0.7)),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(16),
+              borderSide: BorderSide(
+                color: AppColors.borderColor(brightness).withValues(alpha: 0.5),
+              ),
             ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(16),
+              borderSide: BorderSide(color: AppColors.terminalGreen, width: 2),
+            ),
+            errorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(16),
+              borderSide: BorderSide(
+                color: AppColors.githubErrorLight,
+                width: 2,
+              ),
+            ),
+            focusedErrorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(16),
+              borderSide: BorderSide(
+                color: AppColors.githubErrorLight,
+                width: 2,
+              ),
+            ),
+          ),
+        ),
+        if (tokenState.error != null) ...[
+          const SizedBox(height: 16),
+          ErrorMessageWidget(message: tokenState.error!),
+        ],
+        if (tokenState.isSaved && tokenState.error == null) ...[
+          const SizedBox(height: 16),
+          const SuccessMessageWidget(message: 'トークンが正常に保存されました'),
+        ],
+        const SizedBox(height: 24),
+        SaveButton(
+          onPressed: tokenState.saveToken,
+          isLoading: tokenState.isLoading,
+        ),
+      ],
+    );
+  }
+}
+
+/// テーマモード選択セクション
+class _ThemeModeSelector extends StatelessWidget {
+  final ThemeState themeState;
+  final Color textColor;
+  final Color iconColor;
+
+  const _ThemeModeSelector({
+    required this.themeState,
+    required this.textColor,
+    required this.iconColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final isDark = brightness == Brightness.dark;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SectionTitle(
+          title: 'テーマ',
+          icon: Icons.palette,
+          textColor: textColor,
+          iconColor: iconColor,
+        ),
+        const SizedBox(height: 16),
+        _ThemeModeOption(
+          title: 'ライト',
+          icon: Icons.light_mode,
+          themeMode: AppThemeMode.light,
+          isSelected: themeState.currentThemeMode == AppThemeMode.light,
+          onTap: () => themeState.changeThemeMode(AppThemeMode.light),
+          textColor: textColor,
+          iconColor: iconColor,
+          isDark: isDark,
+        ),
+        const SizedBox(height: 16),
+        _ThemeModeOption(
+          title: 'ダーク',
+          icon: Icons.dark_mode,
+          themeMode: AppThemeMode.dark,
+          isSelected: themeState.currentThemeMode == AppThemeMode.dark,
+          onTap: () => themeState.changeThemeMode(AppThemeMode.dark),
+          textColor: textColor,
+          iconColor: iconColor,
+          isDark: isDark,
+        ),
+        const SizedBox(height: 16),
+        _ThemeModeOption(
+          title: 'システム設定に従う',
+          icon: Icons.brightness_auto,
+          themeMode: AppThemeMode.system,
+          isSelected: themeState.currentThemeMode == AppThemeMode.system,
+          onTap: () => themeState.changeThemeMode(AppThemeMode.system),
+          textColor: textColor,
+          iconColor: iconColor,
+          isDark: isDark,
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+}
+
+/// テーマモード選択オプション
+class _ThemeModeOption extends StatelessWidget {
+  final String title;
+  final IconData icon;
+  final AppThemeMode themeMode;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final Color textColor;
+  final Color iconColor;
+  final bool isDark;
+
+  const _ThemeModeOption({
+    required this.title,
+    required this.icon,
+    required this.themeMode,
+    required this.isSelected,
+    required this.onTap,
+    required this.textColor,
+    required this.iconColor,
+    required this.isDark,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? (isDark
+                    ? AppColors.githubDarkBorder.withValues(alpha: 0.3)
+                    : AppColors.grey(800).withValues(alpha: 0.1))
+              : isDark
+              ? AppColors.githubDarkBg.withValues(alpha: 0.3)
+              : AppColors.githubLightBg.withValues(alpha: 0.5),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: isSelected
+                ? (isDark ? AppColors.githubLightText : AppColors.grey(800))
+                : AppColors.borderColor(
+                    Theme.of(context).brightness,
+                  ).withValues(alpha: 0.5),
+            width: isSelected ? 2 : 1,
+          ),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              icon,
+              color: isSelected
+                  ? (isDark ? AppColors.githubLightText : AppColors.grey(800))
+                  : iconColor,
+              size: 24,
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                title,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                  color: isSelected
+                      ? (isDark
+                            ? AppColors.githubLightText
+                            : AppColors.grey(800))
+                      : textColor,
+                ),
+              ),
+            ),
+            if (isSelected)
+              Icon(
+                Icons.check_circle,
+                color: isDark ? AppColors.githubLightText : AppColors.grey(800),
+                size: 24,
+              ),
           ],
         ),
       ),

--- a/lib/features/settings/presentation/widgets/error_message_widget.dart
+++ b/lib/features/settings/presentation/widgets/error_message_widget.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_colors.dart';
+
+/// エラーメッセージを表示するウィジェット
+class ErrorMessageWidget extends StatelessWidget {
+  final String message;
+
+  const ErrorMessageWidget({
+    super.key,
+    required this.message,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.githubErrorLight.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: AppColors.githubErrorLight.withValues(alpha: 0.3),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.error_outline,
+            color: AppColors.githubErrorLight,
+            size: 24,
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(
+                color: AppColors.githubErrorLight,
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/settings/presentation/widgets/save_button.dart
+++ b/lib/features/settings/presentation/widgets/save_button.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_colors.dart';
+
+/// ローディング状態を含む保存ボタンウィジェット
+class SaveButton extends StatelessWidget {
+  final VoidCallback? onPressed;
+  final bool isLoading;
+  final String label;
+
+  const SaveButton({
+    super.key,
+    required this.onPressed,
+    this.isLoading = false,
+    this.label = '保存',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: isLoading ? null : onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: AppColors.terminalGreen,
+        foregroundColor: AppColors.githubDarkBg,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        elevation: 0,
+      ),
+      child: isLoading
+          ? const SizedBox(
+              height: 24,
+              width: 24,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  AppColors.githubDarkBg,
+                ),
+              ),
+            )
+          : Text(
+              label,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: AppColors.githubDarkBg,
+              ),
+            ),
+    );
+  }
+}
+

--- a/lib/features/settings/presentation/widgets/section_title.dart
+++ b/lib/features/settings/presentation/widgets/section_title.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_colors.dart';
+
+/// セクションのタイトルと説明を表示するウィジェット
+class SectionTitle extends StatelessWidget {
+  final String title;
+  final String? description;
+  final IconData? icon;
+  final Color? textColor;
+  final Color? iconColor;
+
+  const SectionTitle({
+    super.key,
+    required this.title,
+    this.description,
+    this.icon,
+    this.textColor,
+    this.iconColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final defaultTextColor = textColor ?? AppColors.textColor(brightness);
+    final defaultIconColor = iconColor ?? AppColors.iconColor(brightness);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            if (icon != null) ...[
+              Icon(icon, color: defaultIconColor, size: 24),
+              const SizedBox(width: 16),
+            ],
+            Text(
+              title,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: defaultTextColor,
+              ),
+            ),
+          ],
+        ),
+        if (description != null) ...[
+          const SizedBox(height: 8),
+          Text(
+            description!,
+            style: TextStyle(
+              fontSize: 12,
+              color: defaultTextColor,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+

--- a/lib/features/settings/presentation/widgets/success_message_widget.dart
+++ b/lib/features/settings/presentation/widgets/success_message_widget.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_colors.dart';
+
+/// 成功メッセージを表示するウィジェット
+class SuccessMessageWidget extends StatelessWidget {
+  final String message;
+
+  const SuccessMessageWidget({
+    super.key,
+    required this.message,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final textColor = AppColors.textColor(brightness);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: textColor.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: textColor.withValues(alpha: 0.3),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.check_circle_outline,
+            color: textColor,
+            size: 24,
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(
+                color: textColor,
+                fontSize: 14,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/shared/widgets/geometric_background.dart
+++ b/lib/shared/widgets/geometric_background.dart
@@ -15,10 +15,13 @@ class GeometricBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final isDark = brightness == Brightness.dark;
+
     return Stack(
       children: [
         CustomPaint(
-          painter: _GeometricPatternPainter(animate: animate),
+          painter: _GeometricPatternPainter(animate: animate, isDark: isDark),
           size: Size.infinite,
         ),
         child,
@@ -29,21 +32,31 @@ class GeometricBackground extends StatelessWidget {
 
 class _GeometricPatternPainter extends CustomPainter {
   final bool animate;
+  final bool isDark;
 
-  _GeometricPatternPainter({required this.animate});
+  _GeometricPatternPainter({required this.animate, required this.isDark});
 
   @override
   void paint(Canvas canvas, Size size) {
-    // グラデーション背景（薄くする）
+    // グラデーション背景（テーマに応じて変更）
     final gradient = LinearGradient(
       begin: Alignment.topLeft,
       end: Alignment.bottomRight,
-      colors: [
-        AppColors.darkGrey, // ダークグレー
-        AppColors.darkGreenBlack, // 薄い緑がかったグレー
-        AppColors.darkGreen, // 薄い緑
-        AppColors.darkGrey, // ダークグレーに戻る
-      ],
+      colors: isDark
+          ? [
+              AppColors.darkGrey, // ダークグレー
+              AppColors.darkGreenBlack, // 薄い緑がかったグレー
+              AppColors.darkGreen, // 薄い緑
+              AppColors.darkGrey, // ダークグレーに戻る
+            ]
+          : [
+              AppColors.grey(200), // 明るいグレー
+              Color.lerp(AppColors.grey(100), Colors.red, 0.1) ??
+                  AppColors.grey(100), // 薄い赤がかったグレー
+              Color.lerp(AppColors.grey(50), Colors.red, 0.15) ??
+                  AppColors.grey(50), // より薄い赤がかった色
+              AppColors.grey(200), // 明るいグレーに戻る
+            ],
       stops: const [0.0, 0.4, 0.6, 1.0],
     );
 
@@ -61,9 +74,11 @@ class _GeometricPatternPainter extends CustomPainter {
   /// 網代模様: 斜めの平行線を複数方向に重ねる
   void _drawAjiroPattern(Canvas canvas, Size size) {
     final linePaint = Paint()
-      ..color = AppColors.terminalGreen.withValues(alpha: 0.08)
+      ..color = isDark
+          ? AppColors.terminalGreen.withValues(alpha: 0.25)
+          : AppColors.terminalGreen.withValues(alpha: 0.20)
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 0.8;
+      ..strokeWidth = 2.0;
 
     final spacing = 40.0;
     final diagonalLength = math.sqrt(
@@ -81,9 +96,11 @@ class _GeometricPatternPainter extends CustomPainter {
 
     // 左斜め下方向の平行線
     final leftLinePaint = Paint()
-      ..color = AppColors.terminalGreen.withValues(alpha: 0.06)
+      ..color = isDark
+          ? AppColors.terminalGreen.withValues(alpha: 0.20)
+          : AppColors.terminalGreen.withValues(alpha: 0.18)
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 0.8;
+      ..strokeWidth = 2.0;
 
     for (double i = -diagonalLength; i < diagonalLength; i += spacing) {
       canvas.drawLine(
@@ -97,9 +114,11 @@ class _GeometricPatternPainter extends CustomPainter {
   /// 麻の葉模様: 六角形の中心から各頂点に向かって線を引く
   void _drawAsanohaPattern(Canvas canvas, Size size) {
     final asanohaPaint = Paint()
-      ..color = AppColors.terminalGreen.withValues(alpha: 0.1)
+      ..color = isDark
+          ? AppColors.terminalGreen.withValues(alpha: 0.30)
+          : AppColors.terminalGreen.withValues(alpha: 0.25)
       ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.0;
+      ..strokeWidth = 2.0;
 
     final hexSize = 80.0; // 六角形のサイズ
     final hexRadius = hexSize / 2;
@@ -143,5 +162,6 @@ class _GeometricPatternPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) => animate;
+  bool shouldRepaint(covariant _GeometricPatternPainter oldDelegate) =>
+      animate || oldDelegate.isDark != isDark;
 }

--- a/lib/shared/widgets/glass_container.dart
+++ b/lib/shared/widgets/glass_container.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import '../../core/theme/app_colors.dart';
+
+/// ガラスデザインのContainer
+class GlassContainer extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+
+  const GlassContainer({
+    super.key,
+    required this.child,
+    this.padding,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final isDark = brightness == Brightness.dark;
+
+    return Container(
+      padding: padding ?? const EdgeInsets.all(32),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(
+          color: isDark
+              ? AppColors.githubDarkBorder.withValues(alpha: 0.3)
+              : AppColors.githubLightBorder.withValues(alpha: 0.3),
+          width: 1.5,
+        ),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: isDark
+              ? [
+                  AppColors.githubDarkSurface.withValues(alpha: 0.3),
+                  AppColors.githubDarkSurface.withValues(alpha: 0.1),
+                ]
+              : [
+                  AppColors.white.withValues(alpha: 0.3),
+                  AppColors.white.withValues(alpha: 0.1),
+                ],
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: isDark
+                ? Colors.black.withValues(alpha: 0.3)
+                : Colors.black.withValues(alpha: 0.1),
+            blurRadius: 20,
+            spreadRadius: 0,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(24),
+        child: child,
+      ),
+    );
+  }
+}
+

--- a/lib/shared/widgets/main_navigation.dart
+++ b/lib/shared/widgets/main_navigation.dart
@@ -23,20 +23,36 @@ class MainNavigation extends HookWidget {
       };
     }, []);
 
+    final brightness = Theme.of(context).brightness;
+    final isDark = brightness == Brightness.dark;
+
+    // テーマに応じた色を設定
+    final barBackgroundColor = isDark
+        ? AppColors.githubDarkSurface
+        : AppColors.white;
+    final selectedIconColor = AppColors.terminalGreen;
+    final normalIconColor = isDark
+        ? AppColors.githubUnselectedDark
+        : AppColors.githubUnselectedLight;
+    final circleColor = isDark ? AppColors.githubDarkSurface : AppColors.white;
+    final labelColor = isDark
+        ? AppColors.githubLightText
+        : AppColors.githubDarkText;
+
     final tabItems = [
       TabItem(
         Icons.person,
         "Contribution",
-        AppColors.darkGreenBlack,
-        circleStrokeColor: AppColors.darkGreenBlack,
-        labelStyle: const TextStyle(color: AppColors.white),
+        circleColor,
+        circleStrokeColor: circleColor,
+        labelStyle: TextStyle(color: labelColor),
       ),
       TabItem(
         Icons.settings,
         "Settings",
-        AppColors.darkGreenBlack,
-        circleStrokeColor: AppColors.darkGreenBlack,
-        labelStyle: const TextStyle(color: AppColors.white),
+        circleColor,
+        circleStrokeColor: circleColor,
+        labelStyle: TextStyle(color: labelColor),
       ),
     ];
 
@@ -44,16 +60,15 @@ class MainNavigation extends HookWidget {
 
     return Scaffold(
       extendBody: true,
-      appBar: AppBar(title: const Text('GitHub Contribution App')),
       body: GeometricBackground(child: screens[selectedPos.value]),
       bottomNavigationBar: CircularBottomNavigation(
         tabItems,
         controller: navigationController,
         selectedPos: selectedPos.value,
         barHeight: 80.0,
-        barBackgroundColor: AppColors.darkGrey,
-        selectedIconColor: AppColors.white,
-        normalIconColor: AppColors.grey(400),
+        barBackgroundColor: barBackgroundColor,
+        selectedIconColor: selectedIconColor,
+        normalIconColor: normalIconColor,
         animationDuration: const Duration(milliseconds: 300),
         selectedCallback: (int? selectedPosValue) {
           selectedPos.value = selectedPosValue ?? 0;

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -176,6 +192,102 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "83af5c682796c0f7719c2bbf74792d113e40ae97981b8f266fa84574573556bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.18"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -245,6 +357,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,9 @@ dependencies:
   
   # Circular Bottom Navigation
   circular_bottom_navigation: ^2.4.0
+  
+  # Local Storage
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要

Settings画面にPersonal Access Tokenの入力・保存機能とテーマモード選択機能を実装しました。Feature-Firstアーキテクチャに従い、ドメイン層・データ層・プレゼンテーション層を適切に分離して実装しています。

## 変更内容

- Settings機能のドメイン層とデータ層を実装
  - TokenとThemeModeのエンティティを追加
  - Repositoryインターフェースと実装を追加
  - UseCaseを実装（SaveTokenUseCase、GetTokenUseCase、SaveThemeModeUseCase、GetThemeModeUseCase）
  - ローカルデータソースを実装（SharedPreferencesを使用）

- Settings画面のプレゼンテーション層を実装
  - TokenProviderとThemeProviderを追加（Riverpodを使用）
  - GlassContainerウィジェットを追加
  - 状態管理を実装

- Settings画面のUIを実装
  - Personal Access Token入力フォームを実装
  - トークンのバリデーション機能を実装
  - エラーメッセージと成功メッセージの表示機能を実装
  - テーマモード選択機能を実装（ライト/ダーク/システム設定に従う）
  - 保存機能を実装
  - ルーティングとナビゲーションを追加

- Settings画面のコンポーネント化
  - ErrorMessageWidgetを追加
  - SuccessMessageWidgetを追加
  - SectionTitleを追加
  - SaveButtonを追加
  - コードの可読性と再利用性を向上

- スペーシングを8の倍数に統一
  - すべてのpadding、margin、borderRadiusを8の倍数に統一
  - アイコンサイズを24に統一
  - デザインの一貫性を向上

- その他
  - ThemeNotifierを追加
  - iOS/macOSの依存関係を更新

## 変更の種類

- [x] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [ ] その他:

## 関連 Issue

Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8

## テスト

- [ ] ユニットテストを追加・更新した
- [x] 手動でテストした
- [ ] テスト不要

### テスト内容

- **Personal Access Tokenの入力・保存機能を手動でテスト**
  - トークン入力フォームが正しく表示されることを確認
  - 空のトークンで保存しようとした際にエラーメッセージが表示されることを確認
  - 有効なトークンを入力して保存できることを確認
  - 保存成功時に成功メッセージが表示されることを確認

- **テーマモード選択機能を手動でテスト**
  - ライトモード、ダークモード、システム設定に従うの3つのオプションが表示されることを確認
  - 各オプションを選択した際にテーマが正しく切り替わることを確認
  - 選択中のオプションが視覚的に分かることを確認

- **UIの表示を確認**
  - スペーシングが8の倍数で統一されていることを確認
  - エラーメッセージと成功メッセージが適切に表示されることを確認
  - ローディング状態が正しく表示されることを確認

## スクリーンショット
![simulator_screenshot_DCA3EB33-F506-49E9-A62C-4182E862E946](https://github.com/user-attachments/assets/b6cba021-c008-429b-b738-4c751630d6c7)
<img width="1179" height="2556" alt="simulator_screenshot_CC673766-5CCF-4B86-9B23-EB5266989688" src="https://github.com/user-attachments/assets/d8dd51ff-ea32-43ff-8684-212f97ba829a" />

<!-- UIに変更がある場合は、変更前後のスクリーンショットを追加してください -->

## チェックリスト

- [x] コードレビュー可能な状態である
- [ ] 適切なラベルを付けた
- [ ] ドキュメントを更新した（必要に応じて）
- [x] テストが通ることを確認した
- [x] 競合(conflict)を解決した

## レビュワーへの注意点

## その他

- このPRは6つのコミットに分割されています：
  1. Settings機能のドメイン層とデータ層を実装
  2. Settings画面のプレゼンテーション層を実装
  3. Settings画面のUIを実装
  4. Settings画面のコンポーネント化
  5. スペーシングを8の倍数に統一
  6. iOS/macOSの依存関係を更新

- 実装はFeature-Firstアーキテクチャのガイドラインに従っています
- 状態管理にはRiverpodを使用しています
- ローカルストレージにはSharedPreferencesを使用しています