### PR TITLE
Feature/14 git auth

### DIFF
--- a/lib/core/error/failures.dart
+++ b/lib/core/error/failures.dart
@@ -1,0 +1,37 @@
+/// アプリケーション全体で使用するエラークラス
+
+abstract class Failure {
+  final String message;
+
+  const Failure(this.message);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Failure &&
+          runtimeType == other.runtimeType &&
+          message == other.message;
+
+  @override
+  int get hashCode => message.hashCode;
+}
+
+/// サーバーエラー
+class ServerFailure extends Failure {
+  const ServerFailure(super.message);
+}
+
+/// ネットワークエラー
+class NetworkFailure extends Failure {
+  const NetworkFailure(super.message);
+}
+
+/// 認証エラー（無効なトークンなど）
+class AuthenticationFailure extends Failure {
+  const AuthenticationFailure(super.message);
+}
+
+/// キャッシュエラー
+class CacheFailure extends Failure {
+  const CacheFailure(super.message);
+}

--- a/lib/features/github_contribution/data/datasources/github_remote_datasource.dart
+++ b/lib/features/github_contribution/data/datasources/github_remote_datasource.dart
@@ -1,0 +1,67 @@
+import 'package:dio/dio.dart';
+import '../../domain/entities/user.dart';
+import '../models/user_model.dart';
+
+/// GitHub APIへのリモートアクセスを管理するDataSource
+class GithubRemoteDataSource {
+  static const String _baseUrl = 'https://api.github.com';
+
+  final Dio _dio;
+
+  GithubRemoteDataSource({Dio? dio}) : _dio = dio ?? Dio();
+
+  /// 認証ヘッダーを設定
+  void _setAuthHeader(String token) {
+    _dio.options.headers['Authorization'] = 'token $token';
+    _dio.options.headers['Accept'] = 'application/vnd.github.v3+json';
+  }
+
+  /// 認証されたユーザー情報を取得する
+  Future<User> getAuthenticatedUser(String token) async {
+    try {
+      _setAuthHeader(token);
+      final response = await _dio.get('$_baseUrl/user');
+      
+      if (response.statusCode == 200) {
+        return UserModel.fromJson(response.data as Map<String, dynamic>)
+            .toEntity();
+      } else {
+        throw Exception('ユーザー情報の取得に失敗しました');
+      }
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 401) {
+        throw Exception('認証に失敗しました。トークンが無効です。');
+      } else if (e.response?.statusCode == 403) {
+        throw Exception('アクセスが拒否されました。トークンの権限を確認してください。');
+      } else if (e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        throw Exception('接続がタイムアウトしました。ネットワーク接続を確認してください。');
+      } else if (e.type == DioExceptionType.connectionError) {
+        throw Exception('ネットワークエラーが発生しました。インターネット接続を確認してください。');
+      } else {
+        throw Exception('ユーザー情報の取得に失敗しました: ${e.message}');
+      }
+    } catch (e) {
+      throw Exception('予期しないエラーが発生しました: $e');
+    }
+  }
+
+  /// トークンの有効性を検証する
+  Future<bool> validateToken(String token) async {
+    try {
+      _setAuthHeader(token);
+      final response = await _dio.get('$_baseUrl/user');
+      return response.statusCode == 200;
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 401) {
+        return false;
+      }
+      // ネットワークエラーなどはfalseを返す
+      return false;
+    } catch (e) {
+      return false;
+    }
+  }
+}
+

--- a/lib/features/github_contribution/data/models/user_model.dart
+++ b/lib/features/github_contribution/data/models/user_model.dart
@@ -1,0 +1,54 @@
+import '../../domain/entities/user.dart';
+
+/// GitHubユーザー情報のJSONモデル
+class UserModel extends User {
+  const UserModel({
+    required super.login,
+    required super.name,
+    super.avatarUrl,
+    super.bio,
+    super.publicRepos,
+    super.followers,
+    super.following,
+  });
+
+  /// JSONからUserModelを作成
+  factory UserModel.fromJson(Map<String, dynamic> json) {
+    return UserModel(
+      login: json['login'] as String,
+      name: json['name'] as String? ?? json['login'] as String,
+      avatarUrl: json['avatar_url'] as String?,
+      bio: json['bio'] as String?,
+      publicRepos: json['public_repos'] as int?,
+      followers: json['followers'] as int?,
+      following: json['following'] as int?,
+    );
+  }
+
+  /// UserModelをJSONに変換
+  Map<String, dynamic> toJson() {
+    return {
+      'login': login,
+      'name': name,
+      'avatar_url': avatarUrl,
+      'bio': bio,
+      'public_repos': publicRepos,
+      'followers': followers,
+      'following': following,
+    };
+  }
+
+  /// Entityに変換
+  User toEntity() {
+    return User(
+      login: login,
+      name: name,
+      avatarUrl: avatarUrl,
+      bio: bio,
+      publicRepos: publicRepos,
+      followers: followers,
+      following: following,
+    );
+  }
+}
+

--- a/lib/features/github_contribution/data/repositories/github_repository_impl.dart
+++ b/lib/features/github_contribution/data/repositories/github_repository_impl.dart
@@ -1,0 +1,55 @@
+import 'package:fpdart/fpdart.dart';
+import '../../../../core/error/failures.dart';
+import '../../domain/entities/user.dart';
+import '../../domain/repositories/github_repository.dart';
+import '../datasources/github_remote_datasource.dart';
+
+/// GithubRepositoryの実装
+class GithubRepositoryImpl implements GithubRepository {
+  final GithubRemoteDataSource remoteDataSource;
+
+  GithubRepositoryImpl({GithubRemoteDataSource? remoteDataSource})
+      : remoteDataSource = remoteDataSource ?? GithubRemoteDataSource();
+
+  @override
+  Future<Either<Failure, User>> getAuthenticatedUser(String token) async {
+    try {
+      final user = await remoteDataSource.getAuthenticatedUser(token);
+      return Right(user);
+    } catch (e) {
+      final errorMessage = e.toString().replaceAll('Exception: ', '');
+      
+      if (errorMessage.contains('認証に失敗') ||
+          errorMessage.contains('トークンが無効')) {
+        return Left(AuthenticationFailure(errorMessage));
+      } else if (errorMessage.contains('ネットワーク') ||
+          errorMessage.contains('接続')) {
+        return Left(NetworkFailure(errorMessage));
+      } else {
+        return Left(ServerFailure(errorMessage));
+      }
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> validateToken(String token) async {
+    try {
+      final isValid = await remoteDataSource.validateToken(token);
+      if (isValid) {
+        return const Right(true);
+      } else {
+        return Left(const AuthenticationFailure('トークンが無効です'));
+      }
+    } catch (e) {
+      final errorMessage = e.toString().replaceAll('Exception: ', '');
+      
+      if (errorMessage.contains('ネットワーク') ||
+          errorMessage.contains('接続')) {
+        return Left(NetworkFailure(errorMessage));
+      } else {
+        return Left(ServerFailure(errorMessage));
+      }
+    }
+  }
+}
+

--- a/lib/features/github_contribution/domain/entities/user.dart
+++ b/lib/features/github_contribution/domain/entities/user.dart
@@ -1,0 +1,44 @@
+/// GitHubユーザー情報エンティティ
+class User {
+  final String login;
+  final String name;
+  final String? avatarUrl;
+  final String? bio;
+  final int? publicRepos;
+  final int? followers;
+  final int? following;
+
+  const User({
+    required this.login,
+    required this.name,
+    this.avatarUrl,
+    this.bio,
+    this.publicRepos,
+    this.followers,
+    this.following,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is User &&
+          runtimeType == other.runtimeType &&
+          login == other.login &&
+          name == other.name &&
+          avatarUrl == other.avatarUrl &&
+          bio == other.bio &&
+          publicRepos == other.publicRepos &&
+          followers == other.followers &&
+          following == other.following;
+
+  @override
+  int get hashCode =>
+      login.hashCode ^
+      name.hashCode ^
+      avatarUrl.hashCode ^
+      bio.hashCode ^
+      publicRepos.hashCode ^
+      followers.hashCode ^
+      following.hashCode;
+}
+

--- a/lib/features/github_contribution/domain/repositories/github_repository.dart
+++ b/lib/features/github_contribution/domain/repositories/github_repository.dart
@@ -1,0 +1,21 @@
+import 'package:fpdart/fpdart.dart';
+import '../../../../core/error/failures.dart';
+import '../entities/user.dart';
+
+/// GitHub API操作のリポジトリインターフェース
+abstract class GithubRepository {
+  /// 認証されたユーザー情報を取得する
+  /// 
+  /// [token] GitHub Personal Access Token
+  /// 
+  /// Returns [Either<Failure, User>]
+  Future<Either<Failure, User>> getAuthenticatedUser(String token);
+
+  /// トークンの有効性を検証する
+  /// 
+  /// [token] GitHub Personal Access Token
+  /// 
+  /// Returns [Either<Failure, bool>] true if valid, false otherwise
+  Future<Either<Failure, bool>> validateToken(String token);
+}
+

--- a/lib/features/github_contribution/domain/usecases/get_authenticated_user_usecase.dart
+++ b/lib/features/github_contribution/domain/usecases/get_authenticated_user_usecase.dart
@@ -1,0 +1,24 @@
+import 'package:fpdart/fpdart.dart';
+import '../../../../core/error/failures.dart';
+import '../entities/user.dart';
+import '../repositories/github_repository.dart';
+
+/// 認証されたユーザー情報を取得するUseCase
+class GetAuthenticatedUserUseCase {
+  final GithubRepository repository;
+
+  GetAuthenticatedUserUseCase(this.repository);
+
+  /// 認証されたユーザー情報を取得する
+  /// 
+  /// [token] GitHub Personal Access Token
+  /// 
+  /// Returns [Either<Failure, User>]
+  Future<Either<Failure, User>> call(String token) async {
+    if (token.isEmpty) {
+      return Left(const AuthenticationFailure('トークンが入力されていません'));
+    }
+    return await repository.getAuthenticatedUser(token);
+  }
+}
+

--- a/lib/features/github_contribution/domain/usecases/validate_token_usecase.dart
+++ b/lib/features/github_contribution/domain/usecases/validate_token_usecase.dart
@@ -1,0 +1,23 @@
+import 'package:fpdart/fpdart.dart';
+import '../../../../core/error/failures.dart';
+import '../repositories/github_repository.dart';
+
+/// トークンの有効性を検証するUseCase
+class ValidateTokenUseCase {
+  final GithubRepository repository;
+
+  ValidateTokenUseCase(this.repository);
+
+  /// トークンの有効性を検証する
+  /// 
+  /// [token] GitHub Personal Access Token
+  /// 
+  /// Returns [Either<Failure, bool>] true if valid, false otherwise
+  Future<Either<Failure, bool>> call(String token) async {
+    if (token.isEmpty) {
+      return Left(const AuthenticationFailure('トークンが入力されていません'));
+    }
+    return await repository.validateToken(token);
+  }
+}
+

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -19,6 +19,9 @@ import '../../data/repositories/theme_repository_impl.dart';
 import '../../domain/repositories/token_repository.dart';
 import '../../domain/repositories/theme_repository.dart';
 import '../../domain/entities/theme_mode.dart';
+import '../../../github_contribution/data/repositories/github_repository_impl.dart';
+import '../../../github_contribution/domain/repositories/github_repository.dart';
+import '../../../github_contribution/domain/usecases/validate_token_usecase.dart';
 
 class SettingsScreen extends HookWidget {
   const SettingsScreen({super.key});
@@ -34,9 +37,18 @@ class SettingsScreen extends HookWidget {
     );
     final getTokenUseCase = useMemoized(() => GetTokenUseCase(tokenRepository));
 
+    // GitHub API検証用の依存関係を構築
+    final githubRepository = useMemoized(
+      () => GithubRepositoryImpl() as GithubRepository,
+    );
+    final validateTokenUseCase = useMemoized(
+      () => ValidateTokenUseCase(githubRepository),
+    );
+
     final tokenState = useToken(
       saveTokenUseCase: saveTokenUseCase,
       getTokenUseCase: getTokenUseCase,
+      validateTokenUseCase: validateTokenUseCase,
     );
 
     // テーマ設定用の依存関係を構築

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   fake_async:
     dependency: transitive
     description:
@@ -112,6 +128,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fpdart:
+    dependency: "direct main"
+    description:
+      name: fpdart
+      sha256: f8e9d0989ba293946673e382c59ac513e30cb6746a9452df195f29e3357a73d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   go_router:
     dependency: "direct main"
     description:
@@ -120,6 +144,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.8.1"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -184,6 +216,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -341,6 +381,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,12 @@ dependencies:
   
   # Local Storage
   shared_preferences: ^2.2.2
+  
+  # HTTP Client
+  dio: ^5.4.0
+  
+  # Functional Programming (Either型)
+  fpdart: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要

ローカルに保存されたトークンを使用してGitHub APIへの認証を行う機能を実装しました。
トークンの有効性を検証し、無効なトークンやネットワークエラー時に適切なエラーメッセージを表示する機能を含みます。

## 変更内容

- GitHub API認証用のエンティティ（User）とリポジトリインターフェースを追加
- GitHub API DataSourceを実装（APIクライアント、認証ヘッダー設定、トークン検証）
- エラーハンドリング用のFailureクラス群を実装
- トークン検証UseCaseとユーザー情報取得UseCaseを実装
- 設定画面にトークン検証機能を統合し、保存時にGitHub APIで検証を実行
- 無効なトークンやネットワークエラー時の適切なエラーメッセージ表示を実装

## 変更の種類

- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [ ] その他:

## 関連 Issue

- Closes #15 (GitHub APIサービスクラスの作成)
- Closes #17 (認証ヘッダーの設定)
- Closes #18 (トークン検証APIの呼び出し実装)
- Closes #19 (認証成功/失敗の判定処理)
- Closes #20 (エラーハンドリングとユーザーへのフィードバック)

## テスト

- [ ] ユニットテストを追加・更新した
- [x] 手動でテストした
- [ ] テスト不要

### テスト内容

- 設定画面でGitHub Personal Access Tokenを入力して保存
- 有効なトークンを入力した場合、正常に保存されることを確認
- 無効なトークンを入力した場合、エラーメッセージが表示されることを確認
- ネットワークエラー時のエラーメッセージ表示を確認
- 認証ヘッダーが正しく設定され、APIリクエストが成功することを確認

## スクリーンショット

<!-- UIに変更がある場合は、変更前後のスクリーンショットを追加してください -->

## チェックリスト

- [x] コードレビュー可能な状態である
- [ ] 適切なラベルを付けた
- [ ] ドキュメントを更新した（必要に応じて）
- [ ] テストが通ることを確認した
- [x] 競合(conflict)を解決した


## その他

- 依存関係として`dio`（HTTPクライアント）と`fpdart`（Either型のエラーハンドリング）を追加しました
- `core/error/failures.dart`にエラークラスを追加しました（ServerFailure、NetworkFailure、AuthenticationFailure、CacheFailure）
- GitHub APIのベースURLは`https://api.github.com`を使用しています
- トークンの検証には`/user`エンドポイントを使用しています

