### PR TITLE
Feature/73 friend contribution

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -2,15 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import '../../shared/widgets/main_navigation.dart';
 import '../../features/github_contribution/presentation/screens/contribution_statistics_screen.dart';
+import '../../features/github_contribution/presentation/screens/other_user_contribution_screen.dart';
+import '../../features/github_contribution/presentation/screens/following_users_screen.dart';
 import '../../features/github_contribution/domain/entities/contribution_statistics.dart';
 
 final GoRouter appRouter = GoRouter(
   initialLocation: '/',
   routes: [
-    GoRoute(
-      path: '/',
-      builder: (context, state) => const MainNavigation(),
-    ),
+    GoRoute(path: '/', builder: (context, state) => const MainNavigation()),
     GoRoute(
       path: '/statistics',
       pageBuilder: (context, state) {
@@ -25,6 +24,20 @@ final GoRouter appRouter = GoRouter(
           ),
         );
       },
+    ),
+    GoRoute(
+      path: '/user/:username',
+      pageBuilder: (context, state) {
+        final username = state.pathParameters['username']!;
+        return MaterialPage(
+          key: state.pageKey,
+          child: OtherUserContributionScreen(username: username),
+        );
+      },
+    ),
+    GoRoute(
+      path: '/following',
+      builder: (context, state) => const FollowingUsersScreen(),
     ),
     GoRoute(
       path: '/settings',

--- a/lib/features/github_contribution/data/datasources/github_remote_datasource.dart
+++ b/lib/features/github_contribution/data/datasources/github_remote_datasource.dart
@@ -66,6 +66,42 @@ class GithubRemoteDataSource {
     }
   }
 
+  /// 指定されたユーザー情報を取得する
+  Future<User> getUser(String token, String username) async {
+    try {
+      _setAuthHeader(token);
+      final response = await _dio.get('$_baseUrl/users/$username');
+
+      if (response.statusCode == 200) {
+        return UserModel.fromJson(
+          response.data as Map<String, dynamic>,
+        ).toEntity();
+      } else if (response.statusCode == 404) {
+        throw Exception('ユーザーが見つかりませんでした');
+      } else {
+        throw Exception('ユーザー情報の取得に失敗しました');
+      }
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        throw Exception('ユーザーが見つかりませんでした');
+      } else if (e.response?.statusCode == 401) {
+        throw Exception('認証に失敗しました。トークンが無効です。');
+      } else if (e.response?.statusCode == 403) {
+        throw Exception('アクセスが拒否されました。トークンの権限を確認してください。');
+      } else if (e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        throw Exception('接続がタイムアウトしました。ネットワーク接続を確認してください。');
+      } else if (e.type == DioExceptionType.connectionError) {
+        throw Exception('ネットワークエラーが発生しました。インターネット接続を確認してください。');
+      } else {
+        throw Exception('ユーザー情報の取得に失敗しました: ${e.message}');
+      }
+    } catch (e) {
+      throw Exception('予期しないエラーが発生しました: $e');
+    }
+  }
+
   /// Contributionデータを取得する（GraphQL APIを使用）
   Future<List<Contribution>> getContributions(String token, int year) async {
     try {
@@ -188,6 +224,208 @@ class GithubRemoteDataSource {
         throw Exception(
           errorMessage ?? 'Contributionデータの取得に失敗しました: ${e.message}',
         );
+      }
+    } catch (e) {
+      throw Exception('予期しないエラーが発生しました: $e');
+    }
+  }
+
+  /// 指定されたユーザーのContributionデータを取得する（GraphQL APIを使用）
+  Future<List<Contribution>> getUserContributions(
+    String token,
+    String username,
+    int year,
+  ) async {
+    try {
+      // GraphQL APIのエンドポイント
+      const graphqlUrl = 'https://api.github.com/graphql';
+
+      // GraphQL API用の認証ヘッダー（Bearerトークンを使用）
+      _dio.options.headers['Authorization'] = 'Bearer $token';
+      _dio.options.headers['Accept'] = 'application/vnd.github.v3+json';
+
+      // 開始日と終了日を計算（ISO 8601形式）
+      final startDate = DateTime(year, 1, 1);
+      final today = DateTime.now();
+
+      // 今日のデータを確実に含めるため、翌日の開始時刻（UTC）を終了日として指定
+      final tomorrow = today.add(const Duration(days: 1));
+      final tomorrowStart = DateTime.utc(
+        tomorrow.year,
+        tomorrow.month,
+        tomorrow.day,
+      );
+
+      // 年末と翌日の開始時刻のうち、早い方を使用
+      final yearEndUtc = DateTime.utc(year, 12, 31, 23, 59, 59);
+      final actualEndDate = yearEndUtc.isAfter(tomorrowStart)
+          ? tomorrowStart
+          : yearEndUtc;
+
+      // ISO 8601形式に変換
+      final startDateStr = startDate.toUtc().toIso8601String();
+      final endDateStr = actualEndDate.toIso8601String();
+
+      // GraphQLクエリ（特定のユーザーのContributionデータを取得）
+      final query =
+          '''
+        query {
+          user(login: "$username") {
+            contributionsCollection(from: "$startDateStr", to: "$endDateStr") {
+              contributionCalendar {
+                totalContributions
+                weeks {
+                  contributionDays {
+                    date
+                    contributionCount
+                  }
+                }
+              }
+            }
+          }
+        }
+      ''';
+
+      final response = await _dio.post(graphqlUrl, data: {'query': query});
+
+      if (response.statusCode == 200) {
+        final data = response.data['data'];
+        if (data == null) {
+          throw Exception('Contributionデータの取得に失敗しました');
+        }
+
+        // エラーがある場合（例：ユーザーが見つからない）
+        if (data['user'] == null) {
+          final errors = response.data['errors'] as List<dynamic>?;
+          if (errors != null && errors.isNotEmpty) {
+            final errorMessage =
+                errors[0]['message'] as String? ?? 'ユーザーが見つかりませんでした';
+            throw Exception(errorMessage);
+          }
+          throw Exception('ユーザーが見つかりませんでした');
+        }
+
+        final contributionsCollection = data['user']['contributionsCollection'];
+        if (contributionsCollection == null) {
+          throw Exception('Contributionデータの取得に失敗しました');
+        }
+
+        final contributionCalendar =
+            contributionsCollection['contributionCalendar'];
+        if (contributionCalendar == null) {
+          throw Exception('Contributionデータの取得に失敗しました');
+        }
+
+        final weeks = contributionCalendar['weeks'] as List<dynamic>?;
+        if (weeks == null) {
+          return [];
+        }
+
+        final contributions = <Contribution>[];
+
+        for (final week in weeks) {
+          final contributionDays = week['contributionDays'] as List<dynamic>?;
+          if (contributionDays == null) continue;
+
+          for (final day in contributionDays) {
+            final dateStr = day['date'] as String;
+            final count = day['contributionCount'] as int? ?? 0;
+
+            // 日付文字列をDateTimeに変換（YYYY-MM-DD形式）
+            final dateParts = dateStr.split('-');
+            if (dateParts.length == 3) {
+              final date = DateTime(
+                int.parse(dateParts[0]),
+                int.parse(dateParts[1]),
+                int.parse(dateParts[2]),
+              );
+              contributions.add(Contribution(date: date, count: count));
+            }
+          }
+        }
+
+        contributions.sort((a, b) => a.date.compareTo(b.date));
+        return contributions;
+      } else {
+        throw Exception('Contributionデータの取得に失敗しました');
+      }
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 401) {
+        throw Exception('認証に失敗しました。トークンが無効です。');
+      } else if (e.response?.statusCode == 403) {
+        throw Exception('アクセスが拒否されました。トークンの権限を確認してください。');
+      } else if (e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        throw Exception('接続がタイムアウトしました。ネットワーク接続を確認してください。');
+      } else if (e.type == DioExceptionType.connectionError) {
+        throw Exception('ネットワークエラーが発生しました。インターネット接続を確認してください。');
+      } else {
+        final errorMessage =
+            e.response?.data?['errors']?[0]?['message'] as String?;
+        throw Exception(
+          errorMessage ?? 'Contributionデータの取得に失敗しました: ${e.message}',
+        );
+      }
+    } catch (e) {
+      throw Exception('予期しないエラーが発生しました: $e');
+    }
+  }
+
+  /// フォロー中のユーザー一覧を取得する
+  Future<List<User>> getFollowingUsers(String token) async {
+    try {
+      _setAuthHeader(token);
+      final List<User> followingUsers = [];
+      int page = 1;
+      const perPage = 100; // GitHub APIの最大値
+
+      while (true) {
+        final response = await _dio.get(
+          '$_baseUrl/user/following',
+          queryParameters: {'page': page, 'per_page': perPage},
+        );
+
+        if (response.statusCode == 200) {
+          final List<dynamic> users = response.data as List<dynamic>;
+
+          if (users.isEmpty) {
+            break; // これ以上ユーザーがいない
+          }
+
+          for (final userJson in users) {
+            followingUsers.add(
+              UserModel.fromJson(userJson as Map<String, dynamic>).toEntity(),
+            );
+          }
+
+          // 取得したユーザー数がperPage未満なら最後のページ
+          if (users.length < perPage) {
+            break;
+          }
+
+          page++;
+        } else if (response.statusCode == 404) {
+          break; // フォロー中のユーザーがいない
+        } else {
+          throw Exception('フォロー中のユーザー一覧の取得に失敗しました');
+        }
+      }
+
+      return followingUsers;
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 401) {
+        throw Exception('認証に失敗しました。トークンが無効です。');
+      } else if (e.response?.statusCode == 403) {
+        throw Exception('アクセスが拒否されました。トークンの権限を確認してください。');
+      } else if (e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        throw Exception('接続がタイムアウトしました。ネットワーク接続を確認してください。');
+      } else if (e.type == DioExceptionType.connectionError) {
+        throw Exception('ネットワークエラーが発生しました。インターネット接続を確認してください。');
+      } else {
+        throw Exception('フォロー中のユーザー一覧の取得に失敗しました: ${e.message}');
       }
     } catch (e) {
       throw Exception('予期しないエラーが発生しました: $e');

--- a/lib/features/github_contribution/domain/entities/contribution_statistics.dart
+++ b/lib/features/github_contribution/domain/entities/contribution_statistics.dart
@@ -23,4 +23,3 @@ class ContributionStatistics {
     required this.thisWeekContributions,
   });
 }
-

--- a/lib/features/github_contribution/domain/repositories/github_repository.dart
+++ b/lib/features/github_contribution/domain/repositories/github_repository.dart
@@ -43,4 +43,32 @@ abstract class GithubRepository {
   ///
   /// Returns [Either<Failure, List<Contribution>>]
   Future<Either<Failure, List<Contribution>>> getCachedContributions(int year);
+
+  /// 指定されたユーザー情報を取得する
+  ///
+  /// [token] GitHub Personal Access Token
+  /// [username] 取得するユーザー名
+  ///
+  /// Returns [Either<Failure, User>]
+  Future<Either<Failure, User>> getUser(String token, String username);
+
+  /// 指定されたユーザーのContributionデータを取得する
+  ///
+  /// [token] GitHub Personal Access Token
+  /// [username] 取得するユーザー名
+  /// [year] 取得する年
+  ///
+  /// Returns [Either<Failure, List<Contribution>>]
+  Future<Either<Failure, List<Contribution>>> getUserContributions(
+    String token,
+    String username,
+    int year,
+  );
+
+  /// フォロー中のユーザー一覧を取得する
+  ///
+  /// [token] GitHub Personal Access Token
+  ///
+  /// Returns [Either<Failure, List<User>>]
+  Future<Either<Failure, List<User>>> getFollowingUsers(String token);
 }

--- a/lib/features/github_contribution/domain/usecases/get_following_users_usecase.dart
+++ b/lib/features/github_contribution/domain/usecases/get_following_users_usecase.dart
@@ -1,0 +1,20 @@
+import 'package:fpdart/fpdart.dart';
+import '../../../../core/error/failures.dart';
+import '../../domain/entities/user.dart';
+import '../../domain/repositories/github_repository.dart';
+
+/// フォロー中のユーザー一覧を取得するUseCase
+class GetFollowingUsersUseCase {
+  final GithubRepository repository;
+
+  GetFollowingUsersUseCase(this.repository);
+
+  /// フォロー中のユーザー一覧を取得する
+  ///
+  /// [token] GitHub Personal Access Token
+  ///
+  /// Returns [Either<Failure, List<User>>]
+  Future<Either<Failure, List<User>>> call(String token) async {
+    return await repository.getFollowingUsers(token);
+  }
+}

--- a/lib/features/github_contribution/domain/usecases/get_user_contributions_usecase.dart
+++ b/lib/features/github_contribution/domain/usecases/get_user_contributions_usecase.dart
@@ -1,0 +1,27 @@
+import 'package:fpdart/fpdart.dart';
+import '../../../../core/error/failures.dart';
+import '../entities/contribution.dart';
+import '../repositories/github_repository.dart';
+
+/// 指定されたユーザーのContributionデータを取得するUseCase
+class GetUserContributionsUseCase {
+  final GithubRepository repository;
+
+  GetUserContributionsUseCase(this.repository);
+
+  /// 指定されたユーザーのContributionデータを取得する
+  ///
+  /// [token] GitHub Personal Access Token
+  /// [username] 取得するユーザー名
+  /// [year] 取得する年
+  ///
+  /// Returns [Either<Failure, List<Contribution>>]
+  Future<Either<Failure, List<Contribution>>> call(
+    String token,
+    String username,
+    int year,
+  ) {
+    return repository.getUserContributions(token, username, year);
+  }
+}
+

--- a/lib/features/github_contribution/domain/usecases/get_user_usecase.dart
+++ b/lib/features/github_contribution/domain/usecases/get_user_usecase.dart
@@ -1,0 +1,22 @@
+import 'package:fpdart/fpdart.dart';
+import '../../../../core/error/failures.dart';
+import '../entities/user.dart';
+import '../repositories/github_repository.dart';
+
+/// 指定されたユーザー情報を取得するUseCase
+class GetUserUseCase {
+  final GithubRepository repository;
+
+  GetUserUseCase(this.repository);
+
+  /// 指定されたユーザー情報を取得する
+  ///
+  /// [token] GitHub Personal Access Token
+  /// [username] 取得するユーザー名
+  ///
+  /// Returns [Either<Failure, User>]
+  Future<Either<Failure, User>> call(String token, String username) {
+    return repository.getUser(token, username);
+  }
+}
+

--- a/lib/features/github_contribution/presentation/screens/contribution_statistics_screen.dart
+++ b/lib/features/github_contribution/presentation/screens/contribution_statistics_screen.dart
@@ -27,7 +27,7 @@ class ContributionStatisticsScreen extends StatelessWidget {
       body: GeometricBackground(
         child: SafeArea(
           child: SingleChildScrollView(
-            padding: const EdgeInsets.all(24),
+            padding: const EdgeInsets.all(12),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [

--- a/lib/features/github_contribution/presentation/screens/following_users_screen.dart
+++ b/lib/features/github_contribution/presentation/screens/following_users_screen.dart
@@ -1,0 +1,342 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/error/failures.dart';
+import '../../../../core/error/retry_handler.dart';
+import '../../domain/entities/user.dart';
+import '../../domain/usecases/get_following_users_usecase.dart';
+import '../../../settings/domain/usecases/get_token_usecase.dart';
+import '../../../settings/data/repositories/token_repository_impl.dart';
+import '../../../settings/data/datasources/token_local_datasource.dart';
+import '../../data/repositories/github_repository_impl.dart';
+import '../../domain/repositories/github_repository.dart';
+import '../../../../shared/widgets/glass_container.dart';
+import '../../../../shared/widgets/animated_fade_in.dart';
+import '../../../../shared/widgets/loading_animation.dart';
+import '../../../../shared/widgets/error_display_widget.dart';
+import '../../../../shared/widgets/geometric_background.dart';
+
+/// フォロー中のユーザー一覧画面
+class FollowingUsersScreen extends HookWidget {
+  const FollowingUsersScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final textColor = AppColors.textColor(brightness);
+
+    // DI: 依存関係を構築
+    final tokenRepository = useMemoized(
+      () => TokenRepositoryImpl(TokenLocalDataSource()),
+    );
+    final getTokenUseCase = useMemoized(() => GetTokenUseCase(tokenRepository));
+
+    final githubRepository = useMemoized(
+      () => GithubRepositoryImpl() as GithubRepository,
+    );
+    final getFollowingUsersUseCase = useMemoized(
+      () => GetFollowingUsersUseCase(githubRepository),
+    );
+
+    // 状態管理
+    final followingUsers = useState<List<User>>([]);
+    final isLoading = useState<bool>(true);
+    final isRefreshing = useState<bool>(false);
+    final error = useState<Failure?>(null);
+    final isRetrying = useState<bool>(false);
+
+    // データ取得関数（リトライ機能付き）
+    Future<void> fetchFollowingUsers({bool isRefresh = false}) async {
+      if (!isRefresh) {
+        isLoading.value = true;
+      } else {
+        isRefreshing.value = true;
+      }
+      error.value = null;
+
+      try {
+        // 保存されているトークンを取得
+        final token = await getTokenUseCase();
+        if (token == null || token.value.isEmpty) {
+          error.value = const AuthenticationFailure(
+            'GitHubのアクセストークンが設定されていません。設定画面でトークンを設定してください。',
+          );
+          if (!isRefresh) {
+            isLoading.value = false;
+          } else {
+            isRefreshing.value = false;
+          }
+          return;
+        }
+
+        // フォロー中のユーザー一覧を取得
+        final result = await RetryHandler.executeWithRetry(
+          action: () => getFollowingUsersUseCase(token.value),
+          config: const RetryConfig(
+            maxRetries: 2,
+            initialDelay: Duration(seconds: 1),
+          ),
+        );
+
+        result.fold(
+          (failure) {
+            error.value = failure;
+          },
+          (users) {
+            followingUsers.value = users;
+            error.value = null;
+          },
+        );
+      } catch (e) {
+        error.value = ServerFailure('予期しないエラーが発生しました: $e');
+      } finally {
+        if (!isRefresh) {
+          isLoading.value = false;
+        } else {
+          isRefreshing.value = false;
+        }
+        isRetrying.value = false;
+      }
+    }
+
+    // リトライ関数
+    Future<void> retryFetch() async {
+      isRetrying.value = true;
+      await fetchFollowingUsers(isRefresh: true);
+    }
+
+    // 初期化時にデータを取得
+    useEffect(() {
+      fetchFollowingUsers();
+      return null;
+    }, []);
+
+    return Scaffold(
+      extendBody: true,
+      body: GeometricBackground(
+        child: SafeArea(
+          child: Stack(
+            children: [
+              RefreshIndicator(
+                onRefresh: () => fetchFollowingUsers(isRefresh: true),
+                child: SingleChildScrollView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // ヘッダー
+                      AnimatedFadeIn(
+                        delay: 100.0,
+                        child: Row(
+                          children: [
+                            IconButton(
+                              icon: Icon(Icons.arrow_back, color: textColor),
+                              onPressed: () => context.pop(),
+                            ),
+                            const SizedBox(width: 16),
+                            Text(
+                              'フォロー中のユーザー',
+                              style: TextStyle(
+                                color: textColor,
+                                fontWeight: FontWeight.bold,
+                                fontSize: 20,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      // エラーメッセージ表示
+                      if (error.value != null && !isLoading.value)
+                        AnimatedFadeIn(
+                          delay: 100.0,
+                          child: Padding(
+                            padding: const EdgeInsets.only(bottom: 16),
+                            child: Stack(
+                              children: [
+                                ErrorDisplayWidget(
+                                  failure: error.value!,
+                                  onRetry: isRetrying.value ? null : retryFetch,
+                                ),
+                                if (isRetrying.value)
+                                  Positioned.fill(
+                                    child: Container(
+                                      decoration: BoxDecoration(
+                                        color: Colors.black.withValues(
+                                          alpha: 0.3,
+                                        ),
+                                        borderRadius: BorderRadius.circular(24),
+                                      ),
+                                      child: const Center(
+                                        child: ThemedLoadingAnimation(
+                                          size: 40.0,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      // ユーザー一覧
+                      if (!isLoading.value && error.value == null)
+                        followingUsers.value.isEmpty
+                            ? AnimatedFadeIn(
+                                delay: 100.0,
+                                child: GlassContainer(
+                                  padding: const EdgeInsets.all(24),
+                                  child: Center(
+                                    child: Column(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.center,
+                                      children: [
+                                        Icon(
+                                          Icons.people_outline,
+                                          size: 64,
+                                          color: textColor.withValues(
+                                            alpha: 0.5,
+                                          ),
+                                        ),
+                                        const SizedBox(height: 16),
+                                        Text(
+                                          'フォロー中のユーザーがいません',
+                                          style: TextStyle(
+                                            fontSize: 16,
+                                            color: textColor.withValues(
+                                              alpha: 0.7,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              )
+                            : AnimatedFadeIn(
+                                delay: 100.0,
+                                child: Column(
+                                  children: [
+                                    for (
+                                      int i = 0;
+                                      i < followingUsers.value.length;
+                                      i++
+                                    )
+                                      Padding(
+                                        padding: const EdgeInsets.only(
+                                          bottom: 12,
+                                        ),
+                                        child: AnimatedFadeIn(
+                                          delay: 50.0 * (i + 1),
+                                          child: _UserListItem(
+                                            user: followingUsers.value[i],
+                                            textColor: textColor,
+                                            onTap: () {
+                                              context.push(
+                                                '/user/${followingUsers.value[i].login}',
+                                              );
+                                            },
+                                          ),
+                                        ),
+                                      ),
+                                  ],
+                                ),
+                              ),
+                      const SizedBox(height: 64),
+                    ],
+                  ),
+                ),
+              ),
+              // ローディングインジケーター（初回読み込み時のみ）
+              if (isLoading.value && !isRefreshing.value)
+                Center(child: ThemedLoadingAnimation(size: 80.0)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// ユーザーリストアイテム
+class _UserListItem extends StatelessWidget {
+  final User user;
+  final Color textColor;
+  final VoidCallback onTap;
+
+  const _UserListItem({
+    required this.user,
+    required this.textColor,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassContainer(
+      padding: const EdgeInsets.all(16),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: Row(
+          children: [
+            // アバター
+            if (user.avatarUrl != null)
+              CircleAvatar(
+                radius: 30,
+                backgroundImage: NetworkImage(user.avatarUrl!),
+              )
+            else
+              CircleAvatar(
+                radius: 30,
+                backgroundColor: textColor.withValues(alpha: 0.2),
+                child: Icon(Icons.person, color: textColor, size: 30),
+              ),
+            const SizedBox(width: 16),
+            // ユーザー情報
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    user.name,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: textColor,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '@${user.login}',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: textColor.withValues(alpha: 0.7),
+                    ),
+                  ),
+                  if (user.bio != null && user.bio!.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      user.bio!,
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: textColor.withValues(alpha: 0.6),
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            Icon(
+              Icons.arrow_forward_ios,
+              color: textColor.withValues(alpha: 0.5),
+              size: 16,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/github_contribution/presentation/screens/other_user_contribution_screen.dart
+++ b/lib/features/github_contribution/presentation/screens/other_user_contribution_screen.dart
@@ -1,0 +1,390 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/error/failures.dart';
+import '../../../../core/error/retry_handler.dart';
+import '../widgets/contribution_calendar_widget.dart';
+import '../../domain/entities/contribution.dart';
+import '../../domain/entities/user.dart';
+import '../../domain/usecases/get_user_contributions_usecase.dart';
+import '../../domain/usecases/get_user_usecase.dart';
+import '../../../settings/domain/usecases/get_token_usecase.dart';
+import '../../../settings/data/repositories/token_repository_impl.dart';
+import '../../../settings/data/datasources/token_local_datasource.dart';
+import '../../data/repositories/github_repository_impl.dart';
+import '../../domain/repositories/github_repository.dart';
+import '../../../../shared/widgets/glass_container.dart';
+import '../../../../shared/widgets/animated_fade_in.dart';
+import '../../../../shared/widgets/loading_animation.dart';
+import '../../../../shared/widgets/error_display_widget.dart';
+import '../../../../shared/widgets/statistics_button.dart';
+import '../../../../shared/widgets/geometric_background.dart';
+import '../../domain/usecases/calculate_contribution_statistics_usecase.dart';
+import 'package:go_router/go_router.dart';
+
+/// 他ユーザーのContribution画面
+class OtherUserContributionScreen extends HookWidget {
+  final String username;
+
+  const OtherUserContributionScreen({super.key, required this.username});
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final textColor = AppColors.textColor(brightness);
+
+    // DI: 依存関係を構築
+    final tokenRepository = useMemoized(
+      () => TokenRepositoryImpl(TokenLocalDataSource()),
+    );
+    final getTokenUseCase = useMemoized(() => GetTokenUseCase(tokenRepository));
+
+    final githubRepository = useMemoized(
+      () => GithubRepositoryImpl() as GithubRepository,
+    );
+    final getUserUseCase = useMemoized(() => GetUserUseCase(githubRepository));
+    final getUserContributionsUseCase = useMemoized(
+      () => GetUserContributionsUseCase(githubRepository),
+    );
+    final calculateStatisticsUseCase = useMemoized(
+      () => CalculateContributionStatisticsUseCase(),
+    );
+
+    // 状態管理
+    final user = useState<User?>(null);
+    final contributions = useState<List<Contribution>>([]);
+    final isLoading = useState<bool>(true);
+    final isRefreshing = useState<bool>(false);
+    final error = useState<Failure?>(null);
+    final selectedYear = useState<int>(DateTime.now().year);
+    final isRetrying = useState<bool>(false);
+
+    // データ取得関数（リトライ機能付き）
+    Future<void> fetchUserData({bool isRefresh = false}) async {
+      if (!isRefresh) {
+        isLoading.value = true;
+      } else {
+        isRefreshing.value = true;
+      }
+      error.value = null;
+
+      try {
+        // 保存されているトークンを取得
+        final token = await getTokenUseCase();
+        if (token == null || token.value.isEmpty) {
+          error.value = const AuthenticationFailure(
+            'GitHubのアクセストークンが設定されていません。設定画面でトークンを設定してください。',
+          );
+          if (!isRefresh) {
+            isLoading.value = false;
+          } else {
+            isRefreshing.value = false;
+          }
+          return;
+        }
+
+        // ユーザー情報を取得
+        final userResult = await getUserUseCase(token.value, username);
+        userResult.fold(
+          (failure) {
+            error.value = failure;
+          },
+          (userData) {
+            user.value = userData;
+          },
+        );
+
+        // Contributionデータを取得
+        if (error.value == null) {
+          final result = await RetryHandler.executeWithRetry(
+            action: () => getUserContributionsUseCase(
+              token.value,
+              username,
+              selectedYear.value,
+            ),
+            config: const RetryConfig(
+              maxRetries: 2,
+              initialDelay: Duration(seconds: 1),
+            ),
+          );
+
+          result.fold(
+            (failure) {
+              error.value = failure;
+            },
+            (data) {
+              contributions.value = data;
+              error.value = null;
+            },
+          );
+        }
+      } catch (e) {
+        error.value = ServerFailure('予期しないエラーが発生しました: $e');
+      } finally {
+        if (!isRefresh) {
+          isLoading.value = false;
+        } else {
+          isRefreshing.value = false;
+        }
+        isRetrying.value = false;
+      }
+    }
+
+    // リトライ関数
+    Future<void> retryFetch() async {
+      isRetrying.value = true;
+      await fetchUserData(isRefresh: true);
+    }
+
+    // 初期化時にデータを取得
+    useEffect(() {
+      fetchUserData();
+      return null;
+    }, [selectedYear.value]);
+
+    return Scaffold(
+      extendBody: true,
+      body: GeometricBackground(
+        child: SafeArea(
+          child: Stack(
+            children: [
+              RefreshIndicator(
+                onRefresh: () => fetchUserData(isRefresh: true),
+                child: SingleChildScrollView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding: const EdgeInsets.all(24),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const SizedBox(height: 24),
+                      // ヘッダー
+                      AnimatedFadeIn(
+                        delay: 100.0,
+                        child: Row(
+                          children: [
+                            IconButton(
+                              icon: Icon(Icons.arrow_back, color: textColor),
+                              onPressed: () => context.pop(),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                user.value?.name ?? username,
+                                style: TextStyle(
+                                  color: textColor,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 20,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      // ユーザー情報セクション
+                      if (user.value != null && !isLoading.value)
+                        AnimatedFadeIn(
+                          delay: 100.0,
+                          child: GlassContainer(
+                            padding: const EdgeInsets.all(20),
+                            child: Row(
+                              children: [
+                                // アバター
+                                if (user.value!.avatarUrl != null)
+                                  CircleAvatar(
+                                    radius: 40,
+                                    backgroundImage: NetworkImage(
+                                      user.value!.avatarUrl!,
+                                    ),
+                                  )
+                                else
+                                  CircleAvatar(
+                                    radius: 40,
+                                    backgroundColor: textColor.withValues(
+                                      alpha: 0.2,
+                                    ),
+                                    child: Icon(
+                                      Icons.person,
+                                      color: textColor,
+                                      size: 40,
+                                    ),
+                                  ),
+                                const SizedBox(width: 16),
+                                // ユーザー情報
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        user.value!.name,
+                                        style: TextStyle(
+                                          fontSize: 20,
+                                          fontWeight: FontWeight.bold,
+                                          color: textColor,
+                                        ),
+                                      ),
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        '@${user.value!.login}',
+                                        style: TextStyle(
+                                          fontSize: 14,
+                                          color: textColor.withValues(
+                                            alpha: 0.7,
+                                          ),
+                                        ),
+                                      ),
+                                      if (user.value!.bio != null &&
+                                          user.value!.bio!.isNotEmpty) ...[
+                                        const SizedBox(height: 8),
+                                        Text(
+                                          user.value!.bio!,
+                                          style: TextStyle(
+                                            fontSize: 13,
+                                            color: textColor.withValues(
+                                              alpha: 0.8,
+                                            ),
+                                          ),
+                                          maxLines: 2,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                      ],
+                                    ],
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      if (user.value != null && !isLoading.value)
+                        const SizedBox(height: 24),
+                      // Contributionカレンダーセクション
+                      AnimatedFadeIn(
+                        delay: 150.0,
+                        child: GlassContainer(
+                          padding: const EdgeInsets.all(24),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const SizedBox(height: 16),
+                              Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  AnimatedFadeIn(
+                                    delay: 200.0,
+                                    child: Text(
+                                      'Contribution Calendar',
+                                      style: TextStyle(
+                                        fontSize: 20,
+                                        fontWeight: FontWeight.bold,
+                                        color: textColor,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 24),
+                              // エラーメッセージ表示
+                              if (error.value != null && !isLoading.value)
+                                AnimatedFadeIn(
+                                  delay: 300.0,
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(bottom: 16),
+                                    child: Stack(
+                                      children: [
+                                        ErrorDisplayWidget(
+                                          failure: error.value!,
+                                          onRetry: isRetrying.value
+                                              ? null
+                                              : retryFetch,
+                                        ),
+                                        if (isRetrying.value)
+                                          Positioned.fill(
+                                            child: Container(
+                                              decoration: BoxDecoration(
+                                                color: Colors.black.withValues(
+                                                  alpha: 0.3,
+                                                ),
+                                                borderRadius:
+                                                    BorderRadius.circular(24),
+                                              ),
+                                              child: const Center(
+                                                child: ThemedLoadingAnimation(
+                                                  size: 40.0,
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              // カレンダーウィジェットまたはエラー表示
+                              if (!isLoading.value &&
+                                  error.value == null &&
+                                  contributions.value.isNotEmpty)
+                                AnimatedSwitcher(
+                                  duration: const Duration(milliseconds: 400),
+                                  transitionBuilder: (child, animation) {
+                                    return FadeTransition(
+                                      opacity: animation,
+                                      child: child,
+                                    );
+                                  },
+                                  child: ContributionCalendarWidget(
+                                    key: const ValueKey('calendar'),
+                                    contributions: contributions.value,
+                                    initialYear: selectedYear.value,
+                                    onYearChanged: (newYear) {
+                                      selectedYear.value = newYear;
+                                    },
+                                  ),
+                                )
+                              else if (!isLoading.value &&
+                                  error.value == null &&
+                                  contributions.value.isEmpty)
+                                AnimatedFadeIn(
+                                  delay: 300.0,
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(bottom: 16),
+                                    child: ErrorDisplayWidget(
+                                      failure: const CacheFailure(
+                                        'データが見つかりませんでした。',
+                                      ),
+                                      onRetry: isRetrying.value
+                                          ? null
+                                          : retryFetch,
+                                    ),
+                                  ),
+                                ),
+                              const SizedBox(height: 16),
+                              // 統計データ確認ボタン
+                              if (!isLoading.value &&
+                                  contributions.value.isNotEmpty)
+                                StatisticsButton(
+                                  statistics: calculateStatisticsUseCase(
+                                    contributions.value,
+                                  ),
+                                  year: selectedYear.value,
+                                ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 64),
+                    ],
+                  ),
+                ),
+              ),
+              // ローディングインジケーター（初回読み込み時のみ）
+              if (isLoading.value && !isRefreshing.value)
+                Center(child: ThemedLoadingAnimation(size: 80.0)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/github_contribution/presentation/widgets/contribution_detail_modal.dart
+++ b/lib/features/github_contribution/presentation/widgets/contribution_detail_modal.dart
@@ -61,9 +61,7 @@ class _ContributionDetailModalContent extends StatelessWidget {
             return FadeTransition(
               opacity: AlwaysStoppedAnimation(value),
               child: SlideTransition(
-                position: AlwaysStoppedAnimation(
-                  Offset(0, 1 - value),
-                ),
+                position: AlwaysStoppedAnimation(Offset(0, 1 - value)),
                 child: child,
               ),
             );
@@ -87,7 +85,9 @@ class _ContributionDetailModalContent extends StatelessWidget {
                         end: Alignment.bottomRight,
                         colors: isDark
                             ? [
-                                AppColors.githubDarkSurface.withValues(alpha: 0.85),
+                                AppColors.githubDarkSurface.withValues(
+                                  alpha: 0.85,
+                                ),
                                 AppColors.githubDarkBg.withValues(alpha: 0.85),
                               ]
                             : [
@@ -260,4 +260,3 @@ class _ModalGeometricPatternPainter extends CustomPainter {
   bool shouldRepaint(covariant _ModalGeometricPatternPainter oldDelegate) =>
       oldDelegate.isDark != isDark;
 }
-

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -15,6 +15,7 @@ import '../../../../shared/widgets/glass_container.dart';
 import '../../../../shared/widgets/animated_fade_in.dart';
 import '../../../../shared/widgets/loading_animation.dart';
 import '../../../../shared/widgets/error_display_widget.dart';
+import '../../../../shared/widgets/statistics_button.dart';
 import '../../../github_contribution/domain/usecases/calculate_contribution_statistics_usecase.dart';
 import 'package:go_router/go_router.dart';
 import 'dart:math' as math;
@@ -217,7 +218,37 @@ class ProfileScreen extends HookWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const SizedBox(height: 24),
+                const SizedBox(height: 48),
+                // フォロー中のユーザーボタン
+                AnimatedFadeSlideIn(
+                  delay: 50.0,
+                  child: InkWell(
+                    onTap: () => context.push('/following'),
+                    borderRadius: BorderRadius.circular(16),
+                    child: GlassContainer(
+                      padding: const EdgeInsets.all(12),
+                      child: Row(
+                        children: [
+                          Icon(Icons.people, color: textColor, size: 24),
+
+                          Expanded(
+                            child: Text(
+                              textAlign: TextAlign.center,
+                              '他のユーザーを確認する',
+                              style: TextStyle(fontSize: 16, color: textColor),
+                            ),
+                          ),
+                          Icon(
+                            Icons.arrow_forward_ios,
+                            color: textColor,
+                            size: 16,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
                 // Contributionカレンダーセクション
                 AnimatedFadeSlideIn(
                   delay: 100.0,
@@ -331,59 +362,13 @@ class ProfileScreen extends HookWidget {
                         const SizedBox(height: 16),
                         // 統計データ確認ボタン
                         if (!isLoading.value && contributions.value.isNotEmpty)
-                          AnimatedFadeIn(
-                            delay: 350.0,
-                            child: GlassContainer(
-                              padding: EdgeInsets.zero,
-                              child: Material(
-                                color: Colors.transparent,
-                                child: InkWell(
-                                  onTap: () {
-                                    final statistics =
-                                        calculateStatisticsUseCase(
-                                          contributions.value,
-                                        );
-                                    context.push(
-                                      '/statistics',
-                                      extra: {
-                                        'statistics': statistics,
-                                        'year': selectedYear.value,
-                                      },
-                                    );
-                                  },
-                                  borderRadius: BorderRadius.circular(24),
-                                  child: Container(
-                                    width: double.infinity,
-                                    padding: const EdgeInsets.symmetric(
-                                      vertical: 16,
-                                      horizontal: 20,
-                                    ),
-                                    child: Row(
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.center,
-                                      children: [
-                                        Icon(
-                                          Icons.bar_chart,
-                                          color: textColor,
-                                          size: 20,
-                                        ),
-                                        const SizedBox(width: 8),
-                                        Text(
-                                          '統計データを確認する',
-                                          style: TextStyle(
-                                            color: textColor,
-                                            fontSize: 15,
-                                            fontWeight: FontWeight.w600,
-                                          ),
-                                          textAlign: TextAlign.center,
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                              ),
+                          StatisticsButton(
+                            statistics: calculateStatisticsUseCase(
+                              contributions.value,
                             ),
+                            year: selectedYear.value,
                           ),
+                        const SizedBox(height: 16),
                       ],
                     ),
                   ),

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -193,9 +193,7 @@ class _TokenInputForm extends HookWidget {
         ),
         if (tokenState.error != null) ...[
           const SizedBox(height: 16),
-          AnimatedFadeIn(
-            child: ErrorMessageWidget(message: tokenState.error!),
-          ),
+          AnimatedFadeIn(child: ErrorMessageWidget(message: tokenState.error!)),
         ],
         if (tokenState.isSaved && tokenState.error == null) ...[
           const SizedBox(height: 16),

--- a/lib/shared/widgets/animated_fade_in.dart
+++ b/lib/shared/widgets/animated_fade_in.dart
@@ -26,10 +26,7 @@ class AnimatedFadeIn extends StatelessWidget {
         curve: curve,
       ),
       builder: (context, value, child) {
-        return Opacity(
-          opacity: value,
-          child: child,
-        );
+        return Opacity(opacity: value, child: child);
       },
       child: child,
     );
@@ -120,4 +117,3 @@ class AnimatedFadeSlideIn extends StatelessWidget {
     );
   }
 }
-

--- a/lib/shared/widgets/main_navigation.dart
+++ b/lib/shared/widgets/main_navigation.dart
@@ -75,13 +75,16 @@ class MainNavigation extends HookWidget {
             return FadeTransition(
               opacity: animation,
               child: SlideTransition(
-                position: Tween<Offset>(
-                  begin: const Offset(0.1, 0.0),
-                  end: Offset.zero,
-                ).animate(CurvedAnimation(
-                  parent: animation,
-                  curve: Curves.easeOutCubic,
-                )),
+                position:
+                    Tween<Offset>(
+                      begin: const Offset(0.1, 0.0),
+                      end: Offset.zero,
+                    ).animate(
+                      CurvedAnimation(
+                        parent: animation,
+                        curve: Curves.easeOutCubic,
+                      ),
+                    ),
                 child: child,
               ),
             );
@@ -95,18 +98,18 @@ class MainNavigation extends HookWidget {
       bottomNavigationBar: Opacity(
         opacity: isLoading.value ? 0.5 : 1.0,
         child: CircularBottomNavigation(
-        tabItems,
-        controller: navigationController,
-        selectedPos: selectedPos.value,
-        barHeight: 80.0,
-        barBackgroundColor: barBackgroundColor,
-        selectedIconColor: selectedIconColor,
-        normalIconColor: normalIconColor,
-        animationDuration: const Duration(milliseconds: 300),
-        selectedCallback: (int? selectedPosValue) {
-          selectedPos.value = selectedPosValue ?? 0;
-          navigationController.value = selectedPos.value;
-        },
+          tabItems,
+          controller: navigationController,
+          selectedPos: selectedPos.value,
+          barHeight: 80.0,
+          barBackgroundColor: barBackgroundColor,
+          selectedIconColor: selectedIconColor,
+          normalIconColor: normalIconColor,
+          animationDuration: const Duration(milliseconds: 300),
+          selectedCallback: (int? selectedPosValue) {
+            selectedPos.value = selectedPosValue ?? 0;
+            navigationController.value = selectedPos.value;
+          },
         ),
       ),
     );

--- a/lib/shared/widgets/statistics_button.dart
+++ b/lib/shared/widgets/statistics_button.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../core/theme/app_colors.dart';
+import '../../features/github_contribution/domain/entities/contribution_statistics.dart';
+import 'glass_container.dart';
+import 'animated_fade_in.dart';
+
+/// 統計データ確認ボタン
+class StatisticsButton extends StatelessWidget {
+  final ContributionStatistics statistics;
+  final int year;
+
+  const StatisticsButton({
+    super.key,
+    required this.statistics,
+    required this.year,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final textColor = AppColors.textColor(brightness);
+
+    return AnimatedFadeIn(
+      delay: 350.0,
+      child: GlassContainer(
+        padding: EdgeInsets.zero,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: () {
+              context.push(
+                '/statistics',
+                extra: {'statistics': statistics, 'year': year},
+              );
+            },
+            borderRadius: BorderRadius.circular(24),
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.bar_chart, color: textColor, size: 20),
+                  const SizedBox(width: 8),
+                  Text(
+                    '統計データを確認する',
+                    style: TextStyle(
+                      color: textColor,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 概要

フォロー中のユーザーのContributionを確認できる機能を実装しました。プロフィール画面からフォロー中のユーザー一覧を表示し、各ユーザーのContributionカレンダーと統計情報を確認できるようになりました。

## 変更内容

- GitHub APIを使用してフォロー中のユーザー一覧を取得する機能を実装
- フォロー中のユーザー一覧を表示する画面（FollowingUsersScreen）を追加
- 他ユーザーのContributionカレンダーと統計情報を表示する画面（OtherUserContributionScreen）を追加
- プロフィール画面に「フォロー中のユーザー」ボタンを追加し、一覧画面への遷移を実装
- 統計データ確認ボタンウィジェット（StatisticsButton）を追加
- AppBarを削除し、統計データ画面と同じシンプルな戻るボタンに統一
- ローディングオーバーレイを削除し、ローディングアニメーションのみ表示するように変更
- Contribution統計画面のパディングを調整（24→12）
- コードフォーマットを統一

## 変更の種類

- [x] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [ ] その他:

## 関連 Issue

Closes #73, #74, #75, #76, #77, #78, #79, #80, #81, #82

## テスト

- [ ] ユニットテストを追加・更新した
- [x] 手動でテストした
- [ ] テスト不要

### テスト内容

- プロフィール画面から「フォロー中のユーザー」ボタンをタップして一覧画面が表示されることを確認
- フォロー中のユーザー一覧が正しく表示されることを確認
- 各ユーザーをタップしてContribution画面に遷移することを確認
- 他ユーザーのContributionカレンダーと統計情報が正しく表示されることを確認
- ローディング表示が適切に動作することを確認
- エラーハンドリングが適切に動作することを確認

## スクリーンショット

<!-- UIに変更がある場合は、変更前後のスクリーンショットを追加してください -->

## チェックリスト

- [x] コードレビュー可能な状態である
- [ ] 適切なラベルを付けた
- [ ] ドキュメントを更新した（必要に応じて）
- [ ] テストが通ることを確認した
- [x] 競合(conflict)を解決した

## レビュワーへの注意点

- Feature-Firstアーキテクチャに従って実装しています
- DataSource、Repository、UseCaseの3層構造で実装しています
- エラーハンドリングとリトライ機能を実装しています
- ページネーション対応でフォロー中のユーザーを全件取得しています

## その他

- すべてのコミットに `Closes #73, #74, #75, #76, #77, #78, #79, #80, #81, #82` を追加済みです
- コミットは機能ごとに分割しています