### PR TITLE
Feature/73 friend contribution

### DIFF
--- a/lib/features/github_contribution/domain/entities/user_ranking.dart
+++ b/lib/features/github_contribution/domain/entities/user_ranking.dart
@@ -1,0 +1,14 @@
+import 'user.dart';
+
+/// ユーザーランキング情報を表すエンティティ
+class UserRanking {
+  final User user;
+  final int contributionCount;
+  final int rank;
+
+  const UserRanking({
+    required this.user,
+    required this.contributionCount,
+    required this.rank,
+  });
+}

--- a/lib/features/github_contribution/presentation/screens/following_users_screen.dart
+++ b/lib/features/github_contribution/presentation/screens/following_users_screen.dart
@@ -5,17 +5,21 @@ import '../../../../core/theme/app_colors.dart';
 import '../../../../core/error/failures.dart';
 import '../../../../core/error/retry_handler.dart';
 import '../../domain/entities/user.dart';
+import '../../domain/entities/user_ranking.dart';
 import '../../domain/usecases/get_following_users_usecase.dart';
+import '../../domain/usecases/get_user_contributions_usecase.dart';
+import '../../domain/usecases/get_authenticated_user_usecase.dart';
+import '../../domain/usecases/get_contributions_usecase.dart';
 import '../../../settings/domain/usecases/get_token_usecase.dart';
 import '../../../settings/data/repositories/token_repository_impl.dart';
 import '../../../settings/data/datasources/token_local_datasource.dart';
 import '../../data/repositories/github_repository_impl.dart';
 import '../../domain/repositories/github_repository.dart';
 import '../../../../shared/widgets/glass_container.dart';
-import '../../../../shared/widgets/animated_fade_in.dart';
-import '../../../../shared/widgets/loading_animation.dart';
 import '../../../../shared/widgets/error_display_widget.dart';
 import '../../../../shared/widgets/geometric_background.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
+import 'package:shimmer/shimmer.dart';
 
 /// フォロー中のユーザー一覧画面
 class FollowingUsersScreen extends HookWidget {
@@ -38,13 +42,214 @@ class FollowingUsersScreen extends HookWidget {
     final getFollowingUsersUseCase = useMemoized(
       () => GetFollowingUsersUseCase(githubRepository),
     );
+    final getUserContributionsUseCase = useMemoized(
+      () => GetUserContributionsUseCase(githubRepository),
+    );
+    final getAuthenticatedUserUseCase = useMemoized(
+      () => GetAuthenticatedUserUseCase(githubRepository),
+    );
+    final getContributionsUseCase = useMemoized(
+      () => GetContributionsUseCase(githubRepository),
+    );
 
     // 状態管理
     final followingUsers = useState<List<User>>([]);
+    final weeklyRankings = useState<List<UserRanking>>([]);
+    final allTimeRankings = useState<List<UserRanking>>([]);
+    final selectedTab = useState<int>(0); // 0: 週間, 1: 全期間
     final isLoading = useState<bool>(true);
     final isRefreshing = useState<bool>(false);
     final error = useState<Failure?>(null);
     final isRetrying = useState<bool>(false);
+
+    // ランキングを計算する関数
+    Future<void> _calculateRankings(String token, List<User> users) async {
+      try {
+        final weeklyRankingsList = <UserRanking>[];
+        final allTimeRankingsList = <UserRanking>[];
+
+        // 今週の開始日（月曜日）
+        final today = DateTime.now();
+        final thisWeekStart = today.subtract(Duration(days: today.weekday - 1));
+        final thisWeekStartNormalized = DateTime(
+          thisWeekStart.year,
+          thisWeekStart.month,
+          thisWeekStart.day,
+        );
+
+        // 認証されたユーザーを取得してリストに追加
+        final authenticatedUserResult = await getAuthenticatedUserUseCase(
+          token,
+        );
+        final allUsers = <User>[];
+        authenticatedUserResult.fold(
+          (failure) {
+            // エラーでも続行
+          },
+          (user) {
+            allUsers.add(user);
+          },
+        );
+        allUsers.addAll(users);
+
+        // 各ユーザーのContributionデータを取得
+        for (final user in allUsers) {
+          try {
+            List<int> counts = [0, 0];
+
+            // 認証されたユーザーの場合は自分のContributionデータを使用
+            final isAuthenticatedUser =
+                authenticatedUserResult.isRight() &&
+                authenticatedUserResult
+                        .getOrElse((_) => User(login: '', name: ''))
+                        .login ==
+                    user.login;
+
+            if (isAuthenticatedUser) {
+              // 自分のデータ：今年のデータを取得
+              final contributionsResult = await getContributionsUseCase(
+                token,
+                today.year,
+              );
+              if (contributionsResult.isRight()) {
+                final contributions = contributionsResult.getOrElse((_) => []);
+                // 週間Contribution数を計算
+                final weeklyCount = contributions
+                    .where((c) {
+                      final cDate = DateTime(
+                        c.date.year,
+                        c.date.month,
+                        c.date.day,
+                      );
+                      return !cDate.isBefore(thisWeekStartNormalized);
+                    })
+                    .fold<int>(0, (sum, c) => sum + c.count);
+
+                // 全期間Contribution数（今年と昨年の合計、最低限のデータ）
+                int allTimeCount = contributions.fold<int>(
+                  0,
+                  (sum, c) => sum + c.count,
+                );
+
+                // 昨年のデータも取得（最低限のデータとして）
+                final lastYearResult = await getContributionsUseCase(
+                  token,
+                  today.year - 1,
+                );
+                lastYearResult.fold(
+                  (failure) {
+                    // エラーでも今年のデータのみで続行
+                  },
+                  (lastYearContributions) {
+                    allTimeCount += lastYearContributions.fold<int>(
+                      0,
+                      (sum, c) => sum + c.count,
+                    );
+                  },
+                );
+
+                counts = [weeklyCount, allTimeCount];
+              } else {
+                counts = [0, 0];
+              }
+            } else {
+              // 他のユーザーのデータ：今年のデータを取得
+              final contributionsResult = await getUserContributionsUseCase(
+                token,
+                user.login,
+                today.year,
+              );
+              if (contributionsResult.isRight()) {
+                final contributions = contributionsResult.getOrElse((_) => []);
+                // 週間Contribution数を計算
+                final weeklyCount = contributions
+                    .where((c) {
+                      final cDate = DateTime(
+                        c.date.year,
+                        c.date.month,
+                        c.date.day,
+                      );
+                      return !cDate.isBefore(thisWeekStartNormalized);
+                    })
+                    .fold<int>(0, (sum, c) => sum + c.count);
+
+                // 全期間Contribution数（今年と昨年の合計、最低限のデータ）
+                int allTimeCount = contributions.fold<int>(
+                  0,
+                  (sum, c) => sum + c.count,
+                );
+
+                // 昨年のデータも取得（最低限のデータとして）
+                final lastYearResult = await getUserContributionsUseCase(
+                  token,
+                  user.login,
+                  today.year - 1,
+                );
+                lastYearResult.fold(
+                  (failure) {
+                    // エラーでも今年のデータのみで続行
+                  },
+                  (lastYearContributions) {
+                    allTimeCount += lastYearContributions.fold<int>(
+                      0,
+                      (sum, c) => sum + c.count,
+                    );
+                  },
+                );
+
+                counts = [weeklyCount, allTimeCount];
+              } else {
+                counts = [0, 0];
+              }
+            }
+
+            weeklyRankingsList.add(
+              UserRanking(user: user, contributionCount: counts[0], rank: 0),
+            );
+            allTimeRankingsList.add(
+              UserRanking(user: user, contributionCount: counts[1], rank: 0),
+            );
+          } catch (e) {
+            // エラーの場合は0として扱う
+            weeklyRankingsList.add(
+              UserRanking(user: user, contributionCount: 0, rank: 0),
+            );
+            allTimeRankingsList.add(
+              UserRanking(user: user, contributionCount: 0, rank: 0),
+            );
+          }
+        }
+
+        // ランキング順にソート（降順）
+        weeklyRankingsList.sort(
+          (a, b) => b.contributionCount.compareTo(a.contributionCount),
+        );
+        allTimeRankingsList.sort(
+          (a, b) => b.contributionCount.compareTo(a.contributionCount),
+        );
+
+        // 順位を設定
+        weeklyRankings.value = weeklyRankingsList.asMap().entries.map((entry) {
+          return UserRanking(
+            user: entry.value.user,
+            contributionCount: entry.value.contributionCount,
+            rank: entry.key + 1,
+          );
+        }).toList();
+
+        allTimeRankings.value = allTimeRankingsList.asMap().entries.map((
+          entry,
+        ) {
+          return UserRanking(
+            user: entry.value.user,
+            contributionCount: entry.value.contributionCount,
+            rank: entry.key + 1,
+          );
+        }).toList();
+      } catch (e) {
+        // エラーを無視（既にエラーハンドリング済み）
+      }
+    }
 
     // データ取得関数（リトライ機能付き）
     Future<void> fetchFollowingUsers({bool isRefresh = false}) async {
@@ -86,6 +291,10 @@ class FollowingUsersScreen extends HookWidget {
           (users) {
             followingUsers.value = users;
             error.value = null;
+            // ランキングを計算（非同期で実行）
+            if (users.isNotEmpty) {
+              _calculateRankings(token.value, users);
+            }
           },
         );
       } catch (e) {
@@ -115,10 +324,10 @@ class FollowingUsersScreen extends HookWidget {
     return Scaffold(
       extendBody: true,
       body: GeometricBackground(
-        child: SafeArea(
-          child: Stack(
-            children: [
-              RefreshIndicator(
+        child: Stack(
+          children: [
+            SafeArea(
+              child: RefreshIndicator(
                 onRefresh: () => fetchFollowingUsers(isRefresh: true),
                 child: SingleChildScrollView(
                   physics: const AlwaysScrollableScrollPhysics(),
@@ -127,131 +336,337 @@ class FollowingUsersScreen extends HookWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       // ヘッダー
-                      AnimatedFadeIn(
-                        delay: 100.0,
-                        child: Row(
-                          children: [
-                            IconButton(
-                              icon: Icon(Icons.arrow_back, color: textColor),
-                              onPressed: () => context.pop(),
-                            ),
-                            const SizedBox(width: 16),
-                            Text(
-                              'フォロー中のユーザー',
-                              style: TextStyle(
-                                color: textColor,
-                                fontWeight: FontWeight.bold,
-                                fontSize: 20,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(height: 24),
-                      // エラーメッセージ表示
-                      if (error.value != null && !isLoading.value)
-                        AnimatedFadeIn(
-                          delay: 100.0,
-                          child: Padding(
-                            padding: const EdgeInsets.only(bottom: 16),
-                            child: Stack(
-                              children: [
-                                ErrorDisplayWidget(
-                                  failure: error.value!,
-                                  onRetry: isRetrying.value ? null : retryFetch,
-                                ),
-                                if (isRetrying.value)
-                                  Positioned.fill(
-                                    child: Container(
-                                      decoration: BoxDecoration(
-                                        color: Colors.black.withValues(
-                                          alpha: 0.3,
-                                        ),
-                                        borderRadius: BorderRadius.circular(24),
-                                      ),
-                                      child: const Center(
-                                        child: ThemedLoadingAnimation(
-                                          size: 40.0,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                              ],
+                      Row(
+                        children: [
+                          IconButton(
+                            icon: Icon(Icons.arrow_back, color: textColor),
+                            onPressed: () => context.pop(),
+                          ),
+                          const SizedBox(width: 16),
+                          Text(
+                            'フォロー中のユーザー',
+                            style: TextStyle(
+                              color: textColor,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 20,
                             ),
                           ),
+                          const Spacer(),
+                          // ローディングインジケーター（初回読み込み時のみ）
+                          if (isLoading.value && !isRefreshing.value)
+                            Padding(
+                              padding: const EdgeInsets.only(right: 16),
+                              child: SpinKitFadingCube(
+                                color: AppColors.terminalGreen,
+                                size: 24.0,
+                              ),
+                            ),
+                          // ランキングデータ取得中のローディング
+                          if (!isLoading.value &&
+                              error.value == null &&
+                              followingUsers.value.isNotEmpty &&
+                              (selectedTab.value == 0
+                                      ? weeklyRankings.value
+                                      : allTimeRankings.value)
+                                  .isEmpty)
+                            Padding(
+                              padding: const EdgeInsets.only(right: 16),
+                              child: SpinKitFadingCube(
+                                color: AppColors.terminalGreen,
+                                size: 24.0,
+                              ),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+                      // タブ切り替え
+                      if (error.value == null &&
+                          followingUsers.value.isNotEmpty)
+                        _RankingTabs(
+                          selectedIndex: selectedTab.value,
+                          onTabChanged: (index) {
+                            selectedTab.value = index;
+                          },
+                          textColor: textColor,
                         ),
-                      // ユーザー一覧
-                      if (!isLoading.value && error.value == null)
-                        followingUsers.value.isEmpty
-                            ? AnimatedFadeIn(
-                                delay: 100.0,
-                                child: GlassContainer(
-                                  padding: const EdgeInsets.all(24),
-                                  child: Center(
-                                    child: Column(
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.center,
-                                      children: [
-                                        Icon(
-                                          Icons.people_outline,
-                                          size: 64,
-                                          color: textColor.withValues(
-                                            alpha: 0.5,
-                                          ),
-                                        ),
-                                        const SizedBox(height: 16),
-                                        Text(
-                                          'フォロー中のユーザーがいません',
-                                          style: TextStyle(
-                                            fontSize: 16,
-                                            color: textColor.withValues(
-                                              alpha: 0.7,
-                                            ),
-                                          ),
-                                        ),
-                                      ],
+                      if (error.value == null &&
+                          followingUsers.value.isNotEmpty)
+                        const SizedBox(height: 16),
+                      // エラーメッセージ表示
+                      if (error.value != null && !isLoading.value)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 16),
+                          child: Stack(
+                            children: [
+                              ErrorDisplayWidget(
+                                failure: error.value!,
+                                onRetry: isRetrying.value ? null : retryFetch,
+                              ),
+                              if (isRetrying.value)
+                                Positioned.fill(
+                                  child: Container(
+                                    decoration: BoxDecoration(
+                                      color: Colors.black.withValues(
+                                        alpha: 0.3,
+                                      ),
+                                      borderRadius: BorderRadius.circular(24),
+                                    ),
+                                    child: Center(
+                                      child: SpinKitFadingCube(
+                                        color: AppColors.terminalGreen,
+                                        size: 40.0,
+                                      ),
                                     ),
                                   ),
                                 ),
-                              )
-                            : AnimatedFadeIn(
-                                delay: 100.0,
-                                child: Column(
-                                  children: [
-                                    for (
-                                      int i = 0;
-                                      i < followingUsers.value.length;
-                                      i++
-                                    )
-                                      Padding(
-                                        padding: const EdgeInsets.only(
-                                          bottom: 12,
-                                        ),
-                                        child: AnimatedFadeIn(
-                                          delay: 50.0 * (i + 1),
-                                          child: _UserListItem(
-                                            user: followingUsers.value[i],
-                                            textColor: textColor,
-                                            onTap: () {
-                                              context.push(
-                                                '/user/${followingUsers.value[i].login}',
-                                              );
-                                            },
-                                          ),
-                                        ),
-                                      ),
-                                  ],
-                                ),
+                            ],
+                          ),
+                        ),
+                      // ランキング表示
+                      if (error.value == null)
+                        // 初回ローディング中は何も表示しない（スケルトンUIは別で表示）
+                        if (isLoading.value && !isRefreshing.value)
+                          _SkeletonRankingList()
+                        else if (!isLoading.value &&
+                            followingUsers.value.isEmpty)
+                          GlassContainer(
+                            padding: const EdgeInsets.all(24),
+                            child: Center(
+                              child: Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(
+                                    Icons.people_outline,
+                                    size: 64,
+                                    color: textColor.withValues(alpha: 0.5),
+                                  ),
+                                  const SizedBox(height: 16),
+                                  Text(
+                                    'フォロー中のユーザーがいません',
+                                    style: TextStyle(
+                                      fontSize: 16,
+                                      color: textColor.withValues(alpha: 0.7),
+                                    ),
+                                  ),
+                                ],
                               ),
+                            ),
+                          )
+                        else if ((selectedTab.value == 0
+                                ? weeklyRankings.value
+                                : allTimeRankings.value)
+                            .isEmpty)
+                          _SkeletonRankingList()
+                        else
+                          Column(
+                            children: [
+                              for (
+                                int i = 0;
+                                i <
+                                    (selectedTab.value == 0
+                                        ? weeklyRankings.value.length
+                                        : allTimeRankings.value.length);
+                                i++
+                              )
+                                Padding(
+                                  padding: const EdgeInsets.only(bottom: 12),
+                                  child: _RankingItem(
+                                    ranking: selectedTab.value == 0
+                                        ? weeklyRankings.value[i]
+                                        : allTimeRankings.value[i],
+                                    textColor: textColor,
+                                    onTap: () {
+                                      context.push(
+                                        '/user/${(selectedTab.value == 0 ? weeklyRankings.value[i] : allTimeRankings.value[i]).user.login}',
+                                      );
+                                    },
+                                  ),
+                                ),
+                            ],
+                          ),
                       const SizedBox(height: 64),
                     ],
                   ),
                 ),
               ),
-              // ローディングインジケーター（初回読み込み時のみ）
-              if (isLoading.value && !isRefreshing.value)
-                Center(child: ThemedLoadingAnimation(size: 80.0)),
-            ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// スケルトンランキングリスト
+class _SkeletonRankingList extends StatelessWidget {
+  const _SkeletonRankingList();
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final isDark = brightness == Brightness.dark;
+
+    return Column(
+      children: [
+        for (int i = 0; i < 5; i++)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: GlassContainer(
+              padding: const EdgeInsets.all(16),
+              child: Shimmer.fromColors(
+                baseColor: isDark ? Colors.grey.shade800 : Colors.grey.shade300,
+                highlightColor: isDark
+                    ? Colors.grey.shade700
+                    : Colors.grey.shade100,
+                period: const Duration(seconds: 2),
+                child: Row(
+                  children: [
+                    // 順位のスケルトン
+                    Container(
+                      width: 40,
+                      height: 24,
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    // アバターのスケルトン
+                    CircleAvatar(radius: 28, backgroundColor: Colors.white),
+                    const SizedBox(width: 12),
+                    // ユーザー情報のスケルトン
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            width: double.infinity,
+                            height: 16,
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Container(
+                            width: 120,
+                            height: 12,
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    // Contribution数のスケルトン
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Container(
+                          width: 40,
+                          height: 18,
+                          decoration: BoxDecoration(
+                            color: Colors.white,
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Container(
+                          width: 60,
+                          height: 11,
+                          decoration: BoxDecoration(
+                            color: Colors.white,
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// ランキングタブ
+class _RankingTabs extends StatelessWidget {
+  final int selectedIndex;
+  final ValueChanged<int> onTabChanged;
+  final Color textColor;
+
+  const _RankingTabs({
+    required this.selectedIndex,
+    required this.onTabChanged,
+    required this.textColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassContainer(
+      padding: const EdgeInsets.all(4),
+      child: Row(
+        children: [
+          Expanded(
+            child: _TabButton(
+              label: '週間',
+              isSelected: selectedIndex == 0,
+              onTap: () => onTabChanged(0),
+              textColor: textColor,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: _TabButton(
+              label: '全期間',
+              isSelected: selectedIndex == 1,
+              onTap: () => onTabChanged(1),
+              textColor: textColor,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// タブボタン
+class _TabButton extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final Color textColor;
+
+  const _TabButton({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+    required this.textColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? AppColors.terminalGreen.withValues(alpha: 0.2)
+              : Colors.transparent,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          label,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: isSelected ? AppColors.terminalGreen : textColor,
+            fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+            fontSize: 14,
           ),
         ),
       ),
@@ -259,14 +674,14 @@ class FollowingUsersScreen extends HookWidget {
   }
 }
 
-/// ユーザーリストアイテム
-class _UserListItem extends StatelessWidget {
-  final User user;
+/// ランキングアイテム
+class _RankingItem extends StatelessWidget {
+  final UserRanking ranking;
   final Color textColor;
   final VoidCallback onTap;
 
-  const _UserListItem({
-    required this.user,
+  const _RankingItem({
+    required this.ranking,
     required this.textColor,
     required this.onTap,
   });
@@ -280,26 +695,42 @@ class _UserListItem extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
         child: Row(
           children: [
+            // 順位
+            Container(
+              width: 40,
+              alignment: Alignment.center,
+              child: Text(
+                '${ranking.rank}',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: ranking.rank <= 3
+                      ? AppColors.terminalGreen
+                      : textColor.withValues(alpha: 0.7),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
             // アバター
-            if (user.avatarUrl != null)
+            if (ranking.user.avatarUrl != null)
               CircleAvatar(
-                radius: 30,
-                backgroundImage: NetworkImage(user.avatarUrl!),
+                radius: 28,
+                backgroundImage: NetworkImage(ranking.user.avatarUrl!),
               )
             else
               CircleAvatar(
-                radius: 30,
+                radius: 28,
                 backgroundColor: textColor.withValues(alpha: 0.2),
-                child: Icon(Icons.person, color: textColor, size: 30),
+                child: Icon(Icons.person, color: textColor, size: 28),
               ),
-            const SizedBox(width: 16),
+            const SizedBox(width: 12),
             // ユーザー情報
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    user.name,
+                    ranking.user.name,
                     style: TextStyle(
                       fontSize: 16,
                       fontWeight: FontWeight.bold,
@@ -308,31 +739,35 @@ class _UserListItem extends StatelessWidget {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    '@${user.login}',
+                    '@${ranking.user.login}',
                     style: TextStyle(
-                      fontSize: 14,
+                      fontSize: 13,
                       color: textColor.withValues(alpha: 0.7),
                     ),
                   ),
-                  if (user.bio != null && user.bio!.isNotEmpty) ...[
-                    const SizedBox(height: 4),
-                    Text(
-                      user.bio!,
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: textColor.withValues(alpha: 0.6),
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
                 ],
               ),
             ),
-            Icon(
-              Icons.arrow_forward_ios,
-              color: textColor.withValues(alpha: 0.5),
-              size: 16,
+            // Contribution数
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  '${ranking.contributionCount}',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: AppColors.terminalGreen,
+                  ),
+                ),
+                Text(
+                  'contributions',
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: textColor.withValues(alpha: 0.6),
+                  ),
+                ),
+              ],
             ),
           ],
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -118,6 +118,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_spinkit:
+    dependency: "direct main"
+    description:
+      name: flutter_spinkit
+      sha256: "77850df57c00dc218bfe96071d576a8babec24cf58b2ed121c83cca4a2fdce7f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -336,6 +344,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  shimmer:
+    dependency: "direct main"
+    description:
+      name: shimmer
+      sha256: "5f88c883a22e9f9f299e5ba0e4f7e6054857224976a5d9f839d4ebdc94a14ac9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,8 @@ dependencies:
   
   # Loading Animation
   loading_animation_widget: ^1.3.0
+  flutter_spinkit: ^5.2.2
+  shimmer: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 概要

フォロー中ユーザー画面のローディングUIを改善し、スケルトンUIを実装しました。ローディングアニメーションをFadingCubeに変更し、AppBar右側に配置することで、より洗練されたUXを提供します。

## 変更内容

- `flutter_spinkit: ^5.2.2` パッケージを追加（FadingCubeアニメーション用）
- `shimmer: ^3.0.0` パッケージを追加（スケルトンUI用）
- ローディングアニメーションを`FadingCube`に変更
- ローディングインジケーターをAppBar右側に配置し、サイズを24pxに縮小
- shimmerパッケージを使用してランキングリストのスケルトンUIを実装
- 初回以外のローディング中（ランキングデータ取得中）もスケルトンUIを表示
- タブのスケルトンUIは削除し、常に通常表示に変更
- 初回ローディング中に「フォロー中のユーザーがいません」が一瞬表示される問題を修正

## 変更の種類

- [x] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] テストの追加・修正
- [ ] その他:

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #
Relates to #

## テスト

- [ ] ユニットテストを追加・更新した
- [x] 手動でテストした
- [ ] テスト不要

### テスト内容

- フォロー中ユーザー画面を開き、初回ローディング時にスケルトンUIが表示されることを確認
- タブを切り替えた際に、ランキングデータ取得中にスケルトンUIが表示されることを確認
- AppBar右側にローディングインジケーターが表示されることを確認
- フォロー中のユーザーがいない場合、初回ローディング中に「フォロー中のユーザーがいません」が表示されないことを確認
- ローディング完了後、正しくランキングが表示されることを確認

## スクリーンショット

<!-- UIに変更がある場合は、変更前後のスクリーンショットを追加してください -->

### 変更前
- ローディング中は画面中央に大きなローディングアニメーションが表示
- 初回ローディング中に「フォロー中のユーザーがいません」が一瞬表示される

### 変更後
- ローディング中はスケルトンUIが表示され、AppBar右側に小さなローディングインジケーターが表示
- 初回ローディング中は「フォロー中のユーザーがいません」が表示されない

## チェックリスト

- [x] コードレビュー可能な状態である
- [ ] 適切なラベルを付けた
- [ ] ドキュメントを更新した（必要に応じて）
- [x] テストが通ることを確認した
- [x] 競合(conflict)を解決した

## レビュワーへの注意点

- スケルトンUIの色はダークモード/ライトモードに応じて自動調整されます
- ローディングアニメーションは`flutter_spinkit`パッケージの`SpinKitFadingCube`を使用しています
- スケルトンUIは`shimmer`パッケージの`Shimmer.fromColors`を使用しています

## その他

- 参考記事: [【Flutter】shimmer パッケージを使用して読み込み画面のスケルトンUIを実装する](https://qiita.com/enumura1/items/14dfd88ecdf29f6c2319)
- コミットは以下の2つに分けています：
  1. `chore: ローディングアニメーション用パッケージを追加`
  2. `feat: フォロー中ユーザー画面のローディングUIを改善`

